### PR TITLE
feat: 8 mejoras — cuentas, UX colores, resumen ejecutivo, amortizaciones, periodos, colchón, score, préstamos finalizados

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,31 +78,39 @@ jobs:
 
       # ── 4. Inyectar banner de preview en index.html ────────────────────────
       - name: Inject preview banner
+        env:
+          BRANCH: ${{ steps.slug.outputs.branch }}
+          SHA:    ${{ steps.slug.outputs.sha_short }}
         run: |
-          BRANCH="${{ steps.slug.outputs.branch }}"
-          SHA="${{ steps.slug.outputs.sha_short }}"
-          BANNER=$(cat <<'BANNER_EOF'
-          <style>
-            #preview-banner {
-              position: fixed; top: 0; left: 0; right: 0; z-index: 99999;
-              background: #7c3aed; color: #fff; font-size: 12px;
-              padding: 5px 12px; display: flex; align-items: center;
-              gap: 10px; font-family: monospace; box-shadow: 0 2px 6px rgba(0,0,0,.35);
-            }
-            #preview-banner a { color: #e9d5ff; text-decoration: underline; }
-            body { padding-top: 30px !important; }
-          </style>
-          <div id="preview-banner">
-            🔬 PREVIEW &nbsp;·&nbsp; rama: <strong>BRANCH_PLACEHOLDER</strong>
-            &nbsp;·&nbsp; commit: <code>SHA_PLACEHOLDER</code>
-          </div>
-          BANNER_EOF
+          python3 - <<'PYEOF'
+          import os, sys
+          branch = os.environ['BRANCH']
+          sha    = os.environ['SHA']
+          banner = (
+            '<style>'
+            '#preview-banner{'
+              'position:fixed;top:0;left:0;right:0;z-index:99999;'
+              'background:#7c3aed;color:#fff;font-size:12px;'
+              'padding:5px 12px;display:flex;align-items:center;'
+              'gap:10px;font-family:monospace;box-shadow:0 2px 6px rgba(0,0,0,.35);'
+            '}'
+            'body{padding-top:30px!important}'
+            '</style>'
+            f'<div id="preview-banner">'
+            f'&#x1F52C; PREVIEW &nbsp;&middot;&nbsp; rama: <strong>{branch}</strong>'
+            f'&nbsp;&middot;&nbsp; commit: <code>{sha}</code>'
+            f'</div>'
           )
-          BANNER="${BANNER//BRANCH_PLACEHOLDER/$BRANCH}"
-          BANNER="${BANNER//SHA_PLACEHOLDER/$SHA}"
-          # Insertar justo después de <body>
-          sed -i "s|<body>|<body>\n${BANNER}|" index.html
-          echo "✅ Banner de preview inyectado."
+          with open('index.html', 'r', encoding='utf-8') as f:
+              html = f.read()
+          if '<body>' not in html:
+              print('⚠️  No se encontró <body> en index.html — banner omitido.')
+              sys.exit(0)
+          html = html.replace('<body>', f'<body>\n{banner}', 1)
+          with open('index.html', 'w', encoding='utf-8') as f:
+              f.write(html)
+          print('✅ Banner de preview inyectado.')
+          PYEOF
 
       # ── 5. Desplegar al subdirectorio preview/<slug>/ ──────────────────────
       - name: Deploy preview to gh-pages
@@ -113,7 +121,9 @@ jobs:
           destination_dir: preview/${{ steps.slug.outputs.slug }}
           keep_files:      true          # no borrar el resto de gh-pages
           commit_message:  "preview(${{ steps.slug.outputs.branch }}): ${{ steps.slug.outputs.sha_short }}"
-          exclude_assets:  '.github,.git'
+          exclude_assets: |
+            .github
+            .git
 
       # ── 6. Mostrar URL del preview ─────────────────────────────────────────
       - name: Print preview URL

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,147 @@
+# .github/workflows/deploy-preview.yml
+#
+# FinanceApp — Deploy feature branch preview to GitHub Pages
+#
+# Qué hace este workflow:
+#   1. Se dispara en cada push a ramas `features/**`
+#   2. Calcula un slug a partir del nombre de la rama (ej: features/24_APR_26 → features-24_apr_26)
+#   3. Inyecta las credenciales de Google Drive (igual que en el deploy principal)
+#   4. Inyecta un banner de preview en index.html indicando la rama y el commit
+#   5. Despliega a GitHub Pages bajo el subdirectorio  preview/<slug>/
+#      usando `peaceiris/actions-gh-pages` con keep_files:true
+#      → la raíz del sitio principal (rama main) NO se sobreescribe
+#
+# URL de preview resultante:
+#   https://<org>.github.io/<repo>/preview/<slug>/
+#
+# Requisito de configuración (una sola vez):
+#   En GitHub → Settings → Pages → Build and deployment
+#   selecciona "Deploy from a branch" y elige la rama `gh-pages`.
+#   El workflow principal (deploy.yml) deberá también usar
+#   peaceiris/actions-gh-pages en lugar de actions/deploy-pages si
+#   quieres que ambos despliegues convivan en la misma rama gh-pages.
+#   (Ver nota al final del archivo.)
+#
+# Secrets requeridos (opcionales — igual que en deploy.yml):
+#   GDRIVE_CLIENT_ID, GDRIVE_CLIENT_SECRET
+#
+
+name: Deploy Preview (feature branches)
+
+on:
+  push:
+    branches:
+      - 'features/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write   # necesario para que peaceiris pueda hacer push a gh-pages
+
+concurrency:
+  group:              preview-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      # ── 1. Checkout ────────────────────────────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ── 2. Calcular slug de la rama ────────────────────────────────────────
+      - name: Compute branch slug
+        id: slug
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          # Reemplaza / y caracteres no-alfanuméricos por guión, minúsculas
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's|[^a-z0-9_\-]|-|g')
+          echo "slug=$SLUG"       >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH"   >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(echo '${{ github.sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      # ── 3. Inyectar credenciales de Google Drive ───────────────────────────
+      - name: Inject Google Drive credentials
+        env:
+          GDRIVE_CLIENT_ID:     ${{ secrets.GDRIVE_CLIENT_ID }}
+          GDRIVE_CLIENT_SECRET: ${{ secrets.GDRIVE_CLIENT_SECRET }}
+        run: |
+          if [ -n "$GDRIVE_CLIENT_ID" ] && [ -n "$GDRIVE_CLIENT_SECRET" ]; then
+            echo "✅ Inyectando credenciales de Google Drive..."
+            sed -i "s|%%GDRIVE_CLIENT_ID%%|${GDRIVE_CLIENT_ID}|g"         auth/auth.js
+            sed -i "s|%%GDRIVE_CLIENT_SECRET%%|${GDRIVE_CLIENT_SECRET}|g" auth/auth.js
+          else
+            echo "⚠️  Secrets de Drive no definidos — preview sin soporte Drive."
+          fi
+
+      # ── 4. Inyectar banner de preview en index.html ────────────────────────
+      - name: Inject preview banner
+        run: |
+          BRANCH="${{ steps.slug.outputs.branch }}"
+          SHA="${{ steps.slug.outputs.sha_short }}"
+          BANNER=$(cat <<'BANNER_EOF'
+          <style>
+            #preview-banner {
+              position: fixed; top: 0; left: 0; right: 0; z-index: 99999;
+              background: #7c3aed; color: #fff; font-size: 12px;
+              padding: 5px 12px; display: flex; align-items: center;
+              gap: 10px; font-family: monospace; box-shadow: 0 2px 6px rgba(0,0,0,.35);
+            }
+            #preview-banner a { color: #e9d5ff; text-decoration: underline; }
+            body { padding-top: 30px !important; }
+          </style>
+          <div id="preview-banner">
+            🔬 PREVIEW &nbsp;·&nbsp; rama: <strong>BRANCH_PLACEHOLDER</strong>
+            &nbsp;·&nbsp; commit: <code>SHA_PLACEHOLDER</code>
+          </div>
+          BANNER_EOF
+          )
+          BANNER="${BANNER//BRANCH_PLACEHOLDER/$BRANCH}"
+          BANNER="${BANNER//SHA_PLACEHOLDER/$SHA}"
+          # Insertar justo después de <body>
+          sed -i "s|<body>|<body>\n${BANNER}|" index.html
+          echo "✅ Banner de preview inyectado."
+
+      # ── 5. Desplegar al subdirectorio preview/<slug>/ ──────────────────────
+      - name: Deploy preview to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token:    ${{ secrets.GITHUB_TOKEN }}
+          publish_dir:     .
+          destination_dir: preview/${{ steps.slug.outputs.slug }}
+          keep_files:      true          # no borrar el resto de gh-pages
+          commit_message:  "preview(${{ steps.slug.outputs.branch }}): ${{ steps.slug.outputs.sha_short }}"
+          exclude_assets:  '.github,.git'
+
+      # ── 6. Mostrar URL del preview ─────────────────────────────────────────
+      - name: Print preview URL
+        run: |
+          REPO="${{ github.repository }}"
+          OWNER=$(echo "$REPO" | cut -d/ -f1)
+          REPONAME=$(echo "$REPO" | cut -d/ -f2)
+          SLUG="${{ steps.slug.outputs.slug }}"
+          echo ""
+          echo "🔗 Preview URL:"
+          echo "   https://${OWNER}.github.io/${REPONAME}/preview/${SLUG}/"
+          echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NOTA — Coexistencia con el deploy principal (deploy.yml)
+# ─────────────────────────────────────────────────────────────────────────────
+# Este workflow usa peaceiris/actions-gh-pages que hace push a la rama
+# `gh-pages`.  El deploy.yml actual usa actions/deploy-pages (API oficial).
+# Ambos mecanismos son incompatibles si Pages está en modo "GitHub Actions".
+#
+# Para que los previews funcionen junto con el deploy principal, tienes dos
+# opciones:
+#
+#  A) (Recomendada) Migrar deploy.yml a peaceiris/actions-gh-pages también,
+#     con destination_dir:'.' y keep_files:true. Así ambos conviven en la
+#     misma rama gh-pages y Pages se configura en modo "branch: gh-pages".
+#
+#  B) Usar este workflow solo para tener los archivos en la rama gh-pages
+#     y compartir el link directamente (sin que sea el sitio "oficial").
+#     El deploy principal sigue igual sobre GitHub Pages Actions mode.
+#

--- a/accounts/accounts.js
+++ b/accounts/accounts.js
@@ -19,16 +19,27 @@ const AccountsModule = (() => {
     accounts.forEach(acc=>{
       view.querySelector(`[data-edit-acc="${acc._id}"]`)?.addEventListener('click',()=>openForm(acc._id));
       view.querySelector(`[data-del-acc="${acc._id}"]`)?.addEventListener('click',()=>{
-        if(acc._id==='default'){UI.toast('La cuenta Default no se puede eliminar','err');return;}
+        const accounts = State.get('accounts');
+        if(accounts.length <= 1){UI.toast('Debe existir al menos una cuenta','err');return;}
         if(!UI.confirm('¿Eliminar cuenta?'))return;
-        State.removeItem('accounts',acc._id); render();
+        State.removeItem('accounts',acc._id);
+        State.ensureDefaultAccount();
+        render();
       });
+      view.querySelector(`[data-principal-acc="${acc._id}"]`)?.addEventListener('click',()=>setAsPrincipal(acc._id));
       view.querySelector(`[data-hist-acc="${acc._id}"]`)?.addEventListener('click',()=>openHistorico(acc._id));
     });
   }
 
+  function setAsPrincipal(id) {
+    const accounts = State.get('accounts').map(a => ({...a, esCuentaPrincipal: a._id === id}));
+    State.set('accounts', accounts);
+    UI.toast('Cuenta marcada como principal');
+    render();
+  }
+
   function renderCard(acc) {
-    const isDefault=acc._id==='default';
+    const isPrincipal=acc.esCuentaPrincipal;
     const hist=[...(acc.historicoSaldos||[])].sort((a,b)=>b.fecha.localeCompare(a.fecha));
     const lastHist=hist[0];
     const saldoActual = lastHist ? lastHist.saldo : (acc.saldo||0);
@@ -58,20 +69,21 @@ const AccountsModule = (() => {
         </div>
       </div>` : '';
 
-    return `<div class="card">
+    return `<div class="card" style="${isPrincipal?'border-color:var(--accent2)':''}">
       <div class="flex justify-between items-center mb-12">
         <div class="flex gap-8 items-center" style="flex-wrap:wrap">
           <span class="card-title" style="margin:0">${acc.nombre}</span>
-          ${isDefault?'<span class="badge badge-blue">DEFAULT</span>':''}
+          ${isPrincipal?'<span class="badge badge-blue" title="Cuenta seleccionada por defecto en nuevos gastos">Principal</span>':''}
           ${acc.esFondoPension?'<span class="badge" style="background:rgba(255,209,102,0.15);color:var(--yellow)">🔒 Pensión</span>':''}
           ${acc.simulacion?'<span class="badge badge-sim">SIM</span>':''}
         </div>
         <div class="flex gap-8">
+          ${!isPrincipal?`<button class="btn-icon" data-principal-acc="${acc._id}" title="Marcar como cuenta principal" style="font-size:14px">★</button>`:''}
           <button class="btn-icon" data-hist-acc="${acc._id}" title="Histórico de saldos">
             <svg viewBox="0 0 24 24"><path d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>
           </button>
           <button class="btn-icon" data-edit-acc="${acc._id}"><svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg></button>
-          ${!isDefault?`<button class="btn-danger" data-del-acc="${acc._id}">✕</button>`:''}
+          <button class="btn-danger" data-del-acc="${acc._id}">✕</button>
         </div>
       </div>
       <div class="grid-2 mb-8" style="gap:8px">
@@ -87,7 +99,7 @@ const AccountsModule = (() => {
 
   function openForm(id=null) {
     const acc=id?State.get('accounts').find(a=>a._id===id):null;
-    const isDefault=acc?._id==='default';
+    const isDefault=false; // ya no se restringe el nombre de ninguna cuenta
     const hist=[...(acc?.historicoSaldos||[])].sort((a,b)=>b.fecha.localeCompare(a.fecha));
     const saldoActual = hist[0] ? hist[0].saldo : (acc?.saldo??0);
     const esPension = acc?.esFondoPension || false;
@@ -137,11 +149,10 @@ const AccountsModule = (() => {
   }
 
   function saveAccount(id) {
-    const isDefault=id==='default';
     const nuevoSaldo     = parseFloat(document.getElementById('ac-saldo').value)||0;
     const esFondoPension = document.getElementById('ac-pension')?.checked||false;
     const acc={
-      nombre:         isDefault?'Default':document.getElementById('ac-nombre').value.trim(),
+      nombre:         document.getElementById('ac-nombre').value.trim(),
       saldo:          nuevoSaldo,
       saldoInicial:   parseFloat(document.getElementById('ac-saldo-ini').value)||0,
       fechaInicialSaldo: document.getElementById('ac-fecha-ini').value,
@@ -239,5 +250,5 @@ const AccountsModule = (() => {
     openHistorico(accId);
   }
 
-  return { render, saveAccount, openHistorico, saveHistorico, deleteHistorico };
+  return { render, saveAccount, openHistorico, saveHistorico, deleteHistorico, setAsPrincipal };
 })();

--- a/common/state.js
+++ b/common/state.js
@@ -5,7 +5,7 @@ const State = (() => {
   // saldo        = saldo actual (para intereses)
   // saldoInicial = saldo en fechaInicialSaldo (punto de arranque del extracto)
   // historicoSaldos = [{_id, fecha, saldo, nota}] puntos de control reales
-  const DEFAULT_ACCOUNT = { _id: 'default', nombre: 'Default', saldo: 0, saldoInicial: 0, fechaInicialSaldo: new Date().toISOString().slice(0,10), interes: 0, periodoCobro: 'mensual', descripcion: 'Cuenta principal', activo: true, simulacion: false, historicoSaldos: [] };
+  const DEFAULT_ACCOUNT = { _id: 'default', nombre: 'Default', saldo: 0, saldoInicial: 0, fechaInicialSaldo: new Date().toISOString().slice(0,10), interes: 0, periodoCobro: 'mensual', descripcion: 'Cuenta principal', activo: true, simulacion: false, historicoSaldos: [], esCuentaPrincipal: true };
   const DEFAULT_STATE = {
     loans: [], expenses: [], accounts: [DEFAULT_ACCOUNT], history: [],
     goals: [],      // [{_id,nombre,targetAmount,targetDate,cuentaId,color}]
@@ -18,6 +18,8 @@ const State = (() => {
       tramos_irpf: [[0,19],[12450,24],[20200,30],[35200,37],[60000,45],[300000,47]],
       onboardingDone: false,
       showExecSummary: true,
+      colchonTipo: 'meses',   // 'meses' | 'fijo'
+      colchonFijo: 0,         // € cuando colchonTipo='fijo'
     }
   };
   let state = JSON.parse(JSON.stringify(DEFAULT_STATE));
@@ -31,8 +33,15 @@ const State = (() => {
     state.accounts = (state.accounts || []).map(a => ({
       saldoInicial: 0, fechaInicialSaldo: new Date().toISOString().slice(0,10), historicoSaldos: [],
       esFondoPension: false, bloqueoMeses: 120, impuestoRetirada: 0, aportaciones: [],
+      esCuentaPrincipal: false,
       ...a
     }));
+    // Ensure exactly one account is marked as principal
+    const hasPrincipal = state.accounts.some(a => a.esCuentaPrincipal);
+    if (!hasPrincipal && state.accounts.length > 0) {
+      const target = state.accounts.find(a => a._id === 'default') || state.accounts[0];
+      state.accounts = state.accounts.map(a => ({...a, esCuentaPrincipal: a._id === target._id}));
+    }
     // Migrate: remove obsolete config fields (saldoInicial, saldoInicialFecha)
     delete state.config.saldoInicial;
     delete state.config.saldoInicialFecha;
@@ -41,7 +50,8 @@ const State = (() => {
       colchonMeses:6, showColchon:true, showHistorico:true, histCuenta:'',
       showMC:false, mcIteraciones:300, inflacionGlobal:0,
       tramos_irpf:[[0,19],[12450,24],[20200,30],[35200,37],[60000,45],[300000,47]],
-      onboardingDone:false, showExecSummary:true, showCriticos:true
+      onboardingDone:false, showExecSummary:true, showCriticos:true,
+      colchonTipo:'meses', colchonFijo:0
     };
     for (const [k,v] of Object.entries(cfgDefs)) {
       if (state.config[k] === undefined) state.config[k] = v;
@@ -75,11 +85,28 @@ const State = (() => {
     ensureDefaultAccount();
   }
   function ensureDefaultAccount() {
-    const accounts = state.accounts || [];
-    if (!accounts.find(a => a._id === 'default')) {
-      state.accounts = [{ ...DEFAULT_ACCOUNT }, ...accounts];
+    if (!state.accounts || state.accounts.length === 0) {
+      state.accounts = [{ ...DEFAULT_ACCOUNT }];
       _persist('accounts');
     }
+    // Ensure exactly one account is principal
+    const principals = state.accounts.filter(a => a.esCuentaPrincipal);
+    if (principals.length === 0) {
+      state.accounts = state.accounts.map((a, i) => i === 0 ? {...a, esCuentaPrincipal: true} : a);
+      _persist('accounts');
+    } else if (principals.length > 1) {
+      let found = false;
+      state.accounts = state.accounts.map(a => {
+        if (a.esCuentaPrincipal) { if (!found) { found = true; return a; } return {...a, esCuentaPrincipal: false}; }
+        return a;
+      });
+      _persist('accounts');
+    }
+  }
+  function getPrincipalAccountId() {
+    const accounts = state.accounts || [];
+    const p = accounts.find(a => a.esCuentaPrincipal && a.activo) || accounts.find(a => a.activo);
+    return p ? p._id : 'default';
   }
   function addItem(col, item) { const arr = [...(state[col]||[])]; const ni = { ...item, _id: _uid() }; arr.push(ni); set(col, arr); return ni; }
   function updateItem(col, id, patch) { set(col, (state[col]||[]).map(i => i._id===id ? {...i,...patch} : i)); }
@@ -88,5 +115,5 @@ const State = (() => {
   // Helper: nombres de cuentas para selects
   function accountOptions() { return (state.accounts||[]).map(a => [a._id, a.nombre + (a.simulacion?' (SIM)':'')]); }
   function accountName(id) { const a = (state.accounts||[]).find(a=>a._id===id); return a ? a.nombre : id; }
-  return { get, set, load, addItem, updateItem, removeItem, ensureDefaultAccount, accountOptions, accountName };
+  return { get, set, load, addItem, updateItem, removeItem, ensureDefaultAccount, accountOptions, accountName, getPrincipalAccountId };
 })();

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -161,17 +161,48 @@ const DashboardModule = (() => {
       <!-- Config -->
       <div class="card">
         <div class="grid-2" style="gap:10px">
-          <div class="form-group"><label class="form-label">Periodo inicio</label><input class="form-input" type="date" id="cfg-start" value="${config.dashboardStart}"/></div>
-          <div class="form-group"><label class="form-label">Periodo fin</label><input class="form-input" type="date" id="cfg-end" value="${config.dashboardEnd}"/></div>
+          <div class="form-group">
+            <label class="form-label">Periodo inicio</label>
+            <input class="form-input" type="date" id="cfg-start" value="${config.dashboardStart}"/>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Periodo fin</label>
+            <div class="flex gap-6 flex-wrap items-center" style="row-gap:6px">
+              ${['1M','3M','6M','1Y','5Y','10Y'].map(p=>`<button type="button" class="btn-secondary btn-sm" style="min-width:36px" onclick="DashboardModule.applyPreset('${p}')">${p}</button>`).join('')}
+              <input class="form-input" type="date" id="cfg-end" value="${config.dashboardEnd}" style="width:145px;margin-left:4px"/>
+            </div>
+          </div>
         </div>
         <div class="grid-2 mt-8" style="gap:10px">
           <div class="form-group">
-            <label class="form-label">Colchón económico (meses de gastos básicos)</label>
-            <input class="form-input" type="number" id="cfg-colchon" value="${config.colchonMeses||6}" min="1" max="36"/>
+            <label class="form-label">Colchón económico</label>
+            <div class="flex gap-6 items-center mb-6">
+              <button type="button" class="btn-sm ${(config.colchonTipo||'meses')==='meses'?'btn-primary':'btn-secondary'}" onclick="DashboardModule.setColchonTipo('meses')">Por meses</button>
+              <button type="button" class="btn-sm ${config.colchonTipo==='fijo'?'btn-primary':'btn-secondary'}" onclick="DashboardModule.setColchonTipo('fijo')">Cantidad fija</button>
+            </div>
+            ${config.colchonTipo==='fijo'
+              ? `<div class="flex gap-8 items-center"><input class="form-input" type="number" id="cfg-colchon-fijo" value="${config.colchonFijo||0}" min="0" style="width:130px"/><span class="text-sm" style="color:var(--text2)">€</span></div>`
+              : `<div class="flex gap-8 items-center"><input class="form-input" type="number" id="cfg-colchon" value="${config.colchonMeses||6}" min="1" max="36" style="width:80px"/><span class="text-sm" style="color:var(--text2)">meses de gastos básicos</span></div>`
+            }
+            ${(()=>{
+              const gastoBasMes = FinanceMath.calcGastoBasicoMensual(expenses);
+              if (gastoBasMes <= 0) return `<div class="text-sm mt-6" style="color:var(--text3)">Marca gastos como "básico" para ver la recomendación.</div>`;
+              const meses3 = gastoBasMes * 3, meses6 = gastoBasMes * 6;
+              if (config.colchonTipo === 'fijo') {
+                const equiv = config.colchonFijo > 0 ? (config.colchonFijo / gastoBasMes).toFixed(1) : 0;
+                return `<div class="text-sm mt-6" style="color:var(--text3)">Equivale a <strong style="color:var(--text2)">${equiv} meses</strong> de gastos básicos. Recomendación: entre ${FinanceMath.eur(meses3)} (3m) y ${FinanceMath.eur(meses6)} (6m).</div>`;
+              }
+              const mesesActuales = config.colchonMeses || 6;
+              const colchonActual = gastoBasMes * mesesActuales;
+              const nivel = mesesActuales < 3 ? '⚠️ Por debajo del mínimo recomendado (3 meses).' : mesesActuales < 6 ? '💡 Aceptable. Lo ideal son 6 meses.' : '✅ Colchón sólido.';
+              return `<div class="text-sm mt-6" style="color:var(--text3)">${nivel} Con ${FinanceMath.eur(gastoBasMes)}/mes de básicos: <strong style="color:var(--text2)">${FinanceMath.eur(colchonActual)}</strong>.</div>`;
+            })()}
           </div>
-          <div class="form-group" style="display:flex;align-items:center;gap:10px;padding-top:20px">
-            <label class="toggle"><input type="checkbox" id="cfg-show-hist" ${config.showHistorico?'checked':''}/><span class="toggle-slider"></span></label>
-            <label class="form-label" style="margin:0">Mostrar histórico real en gráfica (cuentas visibles)</label>
+          <div class="form-group" style="display:flex;align-items:flex-start;gap:10px;padding-top:8px;flex-direction:column">
+            <label style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text2)">
+              <label class="toggle"><input type="checkbox" id="cfg-show-hist" ${config.showHistorico?'checked':''}/><span class="toggle-slider"></span></label>
+              Mostrar histórico real en gráfica
+            </label>
           </div>
         </div>
         <div class="flex gap-8 mt-8 items-center flex-wrap">
@@ -199,11 +230,36 @@ const DashboardModule = (() => {
         <button class="btn-secondary btn-sm" onclick="DashboardModule.toggleExecSummary()">${config.showExecSummary!==false?'Ocultar':'Mostrar'}</button>
       </div>
       ${config.showExecSummary!==false?`<div class="exec-summary mb-14">
-        <div class="exec-item"><div class="exec-item-label">Saldo hoy</div><div class="exec-item-val ${saldoHoy>=0?'pos':'neg'}">${FinanceMath.eur(saldoHoy)}</div></div>
-        <div class="exec-item"><div class="exec-item-label">Score salud</div><div class="exec-item-val" style="color:${score.color}">${score.total}/100 ${score.label}</div></div>
-        <div class="exec-item"><div class="exec-item-label">Colchón</div><div class="exec-item-val ${saldoHoy>=colchon?'pos':'neg'}">${FinanceMath.eur(colchon)}</div></div>
-        <div class="exec-item"><div class="exec-item-label">Media gastos/mes</div><div class="exec-item-val neg">${FinanceMath.eur(mediaMensual)}</div></div>
-        ${alertas.length>0?`<div class="exec-item"><div class="exec-item-label">Alertas</div><div class="exec-item-val" style="color:var(--red)">${alertas.length} punto${alertas.length>1?'s':''}</div></div>`:''}
+        <div class="exec-item">
+          <div class="exec-item-label">Saldo hoy</div>
+          <div class="exec-item-val ${saldoHoy>=0?'pos':'neg'}">${FinanceMath.eur(saldoHoy)}</div>
+        </div>
+        <div class="exec-item">
+          <div class="exec-item-label">Score salud</div>
+          <div class="exec-item-val" style="color:${score.color}">${score.total}/100 <span style="font-size:11px;font-family:var(--font-sans)">${score.label}</span></div>
+        </div>
+        <div class="exec-item">
+          <div class="exec-item-label">Ahorro est./mes</div>
+          ${(()=>{
+            const ahorroEst = ingresosMesActual - gastosTosMesActual;
+            const color = ahorroEst > 0 ? 'var(--accent)' : 'var(--red)';
+            return `<div class="exec-item-val" style="color:${color}">${ahorroEst>=0?'+':''}${FinanceMath.eur(ahorroEst)}</div>`;
+          })()}
+        </div>
+        <div class="exec-item">
+          <div class="exec-item-label">Colchón</div>
+          ${(()=>{
+            const cubierto = saldoHoy >= colchon && colchon > 0;
+            const sinConfig = colchon <= 0;
+            if (sinConfig) return `<div class="exec-item-val" style="color:var(--text3)">No configurado</div>`;
+            return `<div class="exec-item-val" style="color:${cubierto?'var(--accent)':'var(--red)'}">${FinanceMath.eur(colchon)} ${cubierto?'✓':'✗'}</div>`;
+          })()}
+        </div>
+        <div class="exec-item">
+          <div class="exec-item-label">Ingresos/mes</div>
+          <div class="exec-item-val" style="color:var(--text)">${FinanceMath.eur(ingresosMesActual||ingresosMediaMes)}</div>
+        </div>
+        ${alertas.length>0?`<div class="exec-item"><div class="exec-item-label">Alertas</div><div class="exec-item-val" style="color:var(--yellow)">${alertas.length} punto${alertas.length>1?'s':''} crítico${alertas.length>1?'s':''}</div></div>`:''}
       </div>`:'<div class="mb-14"></div>'}
 
       <!-- Stats row -->
@@ -245,7 +301,7 @@ const DashboardModule = (() => {
         <!-- Panel 1: Gastos mensuales -->
         <div class="card">
           <div class="card-title mb-12">Gastos mensuales</div>
-          <div class="stat-value neg mb-8">${FinanceMath.eur(gastosFijosMes + cuotasMesActual)}<span class="stat-sub" style="font-size:11px;margin-left:6px">este mes</span></div>
+          <div class="stat-value mb-8" style="color:var(--text)">${FinanceMath.eur(gastosFijosMes + cuotasMesActual)}<span class="stat-sub" style="font-size:11px;margin-left:6px">este mes</span></div>
           <div style="font-size:11px;color:var(--text3);margin-bottom:10px">${FinanceMath.eur(gastosFijosMes)} gastos + ${FinanceMath.eur(cuotasMesActual)} cuotas</div>
           <div style="display:flex;flex-direction:column;gap:5px">
             <div style="display:flex;justify-content:space-between;font-size:12px">
@@ -262,7 +318,7 @@ const DashboardModule = (() => {
         <!-- Panel 2: Endeudamiento -->
         <div class="card">
           <div class="card-title mb-12">Endeudamiento</div>
-          <div class="stat-value neg mb-8">${FinanceMath.eur(cuotasMesActual)}<span class="stat-sub" style="font-size:11px;margin-left:6px">cuotas este mes</span></div>
+          <div class="stat-value mb-8" style="color:var(--text)">${FinanceMath.eur(cuotasMesActual)}<span class="stat-sub" style="font-size:11px;margin-left:6px">cuotas este mes</span></div>
           <div style="font-size:11px;color:var(--text3);margin-bottom:10px">Solo cuotas ordinarias, sin amortizaciones</div>
           <div style="display:flex;flex-direction:column;gap:5px">
             <div style="display:flex;justify-content:space-between;font-size:12px">
@@ -282,7 +338,7 @@ const DashboardModule = (() => {
         <!-- Panel 3: Gastos básicos -->
         <div class="card">
           <div class="card-title mb-12">Gastos básicos + cuotas</div>
-          <div class="stat-value mb-8" style="color:var(--yellow)">${FinanceMath.eur(gastosBasicosMes + cuotasMesActual)}<span class="stat-sub" style="font-size:11px;margin-left:6px">al mes</span></div>
+          <div class="stat-value mb-8" style="color:var(--blue)">${FinanceMath.eur(gastosBasicosMes + cuotasMesActual)}<span class="stat-sub" style="font-size:11px;margin-left:6px">al mes</span></div>
           <div style="font-size:11px;color:var(--text3);margin-bottom:10px">${FinanceMath.eur(gastosBasicosMes)} básicos + ${FinanceMath.eur(cuotasMesActual)} cuotas</div>
           <div style="display:flex;flex-direction:column;gap:5px">
             <div style="display:flex;justify-content:space-between;font-size:12px">
@@ -810,7 +866,7 @@ const DashboardModule = (() => {
         labels,
         datasets: [
           { label:'Ingresos', data:dataIngresos, backgroundColor:'rgba(0,229,160,0.7)', borderWidth:0, borderRadius:2, order:1 },
-          { label:'Cuotas préstamos', data:dataCuotas, backgroundColor:'rgba(255,209,102,0.8)', borderWidth:0, borderRadius:2, stack:'gastos', order:2 },
+          { label:'Cuotas préstamos', data:dataCuotas, backgroundColor:'rgba(168,85,247,0.75)', borderWidth:0, borderRadius:2, stack:'gastos', order:2 },
           { label:'Gastos básicos', data:dataBasicos, backgroundColor:'rgba(77,159,255,0.75)', borderWidth:0, borderRadius:2, stack:'gastos', order:2 },
           { label:'Otros gastos', data:dataOtros, backgroundColor:'rgba(255,77,109,0.65)', borderWidth:0, borderRadius:2, stack:'gastos', order:2 },
         ]
@@ -838,14 +894,37 @@ const DashboardModule = (() => {
     const existing = State.get('config');
     const config={
       ...existing,
-      dashboardStart:  document.getElementById('cfg-start').value,
-      dashboardEnd:    document.getElementById('cfg-end').value,
+      dashboardStart:  document.getElementById('cfg-start').value || existing.dashboardStart,
+      dashboardEnd:    document.getElementById('cfg-end').value || existing.dashboardEnd,
       colchonMeses:    parseInt(document.getElementById('cfg-colchon')?.value)||6,
+      colchonFijo:     parseFloat(document.getElementById('cfg-colchon-fijo')?.value)||0,
       showColchon:     document.getElementById('cfg-show-colchon')?.checked??true,
       showHistorico:   document.getElementById('cfg-show-hist')?.checked??true,
       showMC:          document.getElementById('cfg-show-mc')?.checked??false,
     };
     State.set('config',config); render();
+  }
+  function applyPreset(preset) {
+    const startEl = document.getElementById('cfg-start');
+    const endEl   = document.getElementById('cfg-end');
+    const base = startEl?.value || State.get('config').dashboardStart;
+    const dS   = new Date(base + 'T00:00:00');
+    const dE   = new Date(dS);
+    switch(preset) {
+      case '1M':  dE.setMonth(dE.getMonth()+1);    break;
+      case '3M':  dE.setMonth(dE.getMonth()+3);    break;
+      case '6M':  dE.setMonth(dE.getMonth()+6);    break;
+      case '1Y':  dE.setFullYear(dE.getFullYear()+1); break;
+      case '5Y':  dE.setFullYear(dE.getFullYear()+5); break;
+      case '10Y': dE.setFullYear(dE.getFullYear()+10); break;
+    }
+    if (endEl) endEl.value = dE.toISOString().slice(0,10);
+    applyConfig();
+  }
+  function setColchonTipo(tipo) {
+    const cfg = State.get('config');
+    State.set('config', {...cfg, colchonTipo: tipo});
+    render();
   }
   function setVentana(v) { ventana=v; render(); }
   function toggleTag(t) { if(activeTags.has(t))activeTags.delete(t); else activeTags.add(t); render(); }
@@ -857,5 +936,5 @@ const DashboardModule = (() => {
     render();
   }
 
-  return { render, applyConfig, setVentana, toggleTag, toggleAccFilter, clearAccFilter, toggleExecSummary, toggleScoreDetail, toggleCriticos };
+  return { render, applyConfig, applyPreset, setColchonTipo, setVentana, toggleTag, toggleAccFilter, clearAccFilter, toggleExecSummary, toggleScoreDetail, toggleCriticos };
 })();

--- a/finance-math/finance-math.js
+++ b/finance-math/finance-math.js
@@ -379,16 +379,20 @@ const FinanceMath = (() => {
     return +(beneficioRetirado * acc.impuestoRetirada / 100).toFixed(2);
   }
 
-  // Calcular colchón económico: X meses de gastos básicos
-  // Solo gastos marcados como basico=true — las cuotas de préstamos son deuda
-  // comprometida, no gastos de subsistencia, y no deben inflar el colchón.
-  function calcColchon(expenses, config, loans) {
+  // Retorna el gasto básico mensual (base para el colchón)
+  function calcGastoBasicoMensual(expenses) {
     const hoy = new Date().toISOString().slice(0,10);
     const finMes = new Date(); finMes.setMonth(finMes.getMonth()+1);
     const finMesStr = finMes.toISOString().slice(0,10);
     const gastosBasicos = expenses.filter(e => e.basico && e.activo && e.tipo==='gasto');
     const expEvents = proyectarGastos(gastosBasicos, hoy, finMesStr);
-    const totalMes = expEvents.reduce((s,e)=>s+Math.abs(e.cuantia),0);
+    return expEvents.reduce((s,e)=>s+Math.abs(e.cuantia),0);
+  }
+
+  // Calcular colchón económico: por meses de gastos básicos o cantidad fija
+  function calcColchon(expenses, config, loans) {
+    if (config.colchonTipo === 'fijo' && config.colchonFijo > 0) return config.colchonFijo;
+    const totalMes = calcGastoBasicoMensual(expenses);
     return totalMes * (config.colchonMeses||6);
   }
 
@@ -601,74 +605,75 @@ const FinanceMath = (() => {
   }
 
   // ── Score de salud financiera ────────────────────────────────────────────────
-  // Devuelve 4 métricas con valores, porcentajes y semáforos.
-  // No usa un score arbitrario — cada métrica habla por sí misma.
   function calcScore(extracto, loans, expenses, accounts, config) {
+    // Interpolación lineal acotada
+    function lerp(x, x0, x1, y0, y1) {
+      if (x <= x0) return y0; if (x >= x1) return y1;
+      return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
+    }
 
-    // ── Base: ingresos mensuales netos (activos, tipo ingreso, frecuencia mensual) ──
     const ingresosMes = expenses
       .filter(e => e.activo && e.tipo === 'ingreso' && e.tipoFrecuencia === 'mensual')
       .reduce((s, e) => s + e.cuantia, 0);
 
     // ── 1. Gastos fijos ──────────────────────────────────────────────────────────
-    // Todos los gastos recurrentes mensuales activos (excluye transferencias)
-    const gastosFijosLista = expenses.filter(e =>
-      e.activo && e.tipo === 'gasto' && e.tipoFrecuencia === 'mensual'
-    );
+    const gastosFijosLista = expenses.filter(e => e.activo && e.tipo === 'gasto' && e.tipoFrecuencia === 'mensual');
     const gastosFijosMes = gastosFijosLista.reduce((s, e) => s + e.cuantia, 0);
     const pctFijosIngresos = ingresosMes > 0 ? (gastosFijosMes / ingresosMes) * 100 : null;
-    // Semáforo: 0% es rojo (sin datos), <40% verde, <60% amarillo, ≥60% rojo
-    const colorFijos = gastosFijosMes === 0 ? 'var(--text3)'
-      : pctFijosIngresos === null ? 'var(--text3)'
-      : pctFijosIngresos < 40  ? '#00e5a0'
-      : pctFijosIngresos < 60  ? '#ffd166'
-      : '#ff4d6d';
+    const colorFijos = gastosFijosMes === 0 || pctFijosIngresos === null ? 'var(--text3)'
+      : pctFijosIngresos < 40 ? '#00e5a0' : pctFijosIngresos < 60 ? '#ffd166' : '#ff4d6d';
+    const scoreFijos = pctFijosIngresos === null ? 50
+      : pctFijosIngresos < 30  ? 100
+      : pctFijosIngresos < 50  ? lerp(pctFijosIngresos, 30, 50, 100, 70)
+      : pctFijosIngresos < 70  ? lerp(pctFijosIngresos, 50, 70, 70, 30)
+      : lerp(pctFijosIngresos, 70, 90, 30, 0);
 
     // ── 2. Gastos básicos ────────────────────────────────────────────────────────
-    // Gastos marcados como básico=true (solo mensuales para coherencia con fijos)
     const gastosBasicosLista = gastosFijosLista.filter(e => e.basico);
     const gastosBasicosMes = gastosBasicosLista.reduce((s, e) => s + e.cuantia, 0);
     const pctBasicosIngresos = ingresosMes > 0 ? (gastosBasicosMes / ingresosMes) * 100 : null;
     const pctBasicosSobreFijos = gastosFijosMes > 0 ? (gastosBasicosMes / gastosFijosMes) * 100 : null;
-    // Semáforo: más básico/fijo = mejor. >70% verde, >40% amarillo, <40% rojo
     const colorBasicos = pctBasicosSobreFijos === null ? 'var(--text3)'
-      : pctBasicosSobreFijos > 70 ? '#00e5a0'
-      : pctBasicosSobreFijos > 40 ? '#ffd166'
-      : '#ff4d6d';
+      : pctBasicosSobreFijos > 70 ? '#00e5a0' : pctBasicosSobreFijos > 40 ? '#ffd166' : '#ff4d6d';
 
     // ── 3. Ahorro mensual esperado ───────────────────────────────────────────────
-    // Ingresos - media mensual total de gastos (fijos + variables + cuotas)
     const mediaMensualGastos = FinanceMath.mediaMensualGastos(extracto, config);
     const ahorroMes = ingresosMes - mediaMensualGastos;
     const pctAhorroIngresos = ingresosMes > 0 ? (ahorroMes / ingresosMes) * 100 : null;
-    // Semáforo: >20% verde, >5% amarillo, ≤5% (o negativo) rojo
     const colorAhorro = pctAhorroIngresos === null ? 'var(--text3)'
-      : pctAhorroIngresos > 20 ? '#00e5a0'
-      : pctAhorroIngresos > 5  ? '#ffd166'
-      : '#ff4d6d';
+      : pctAhorroIngresos > 20 ? '#00e5a0' : pctAhorroIngresos > 5 ? '#ffd166' : '#ff4d6d';
+    const scoreAhorro = pctAhorroIngresos === null ? 50
+      : pctAhorroIngresos >= 25  ? 100
+      : pctAhorroIngresos >= 10  ? lerp(pctAhorroIngresos, 10, 25, 65, 100)
+      : pctAhorroIngresos >= 0   ? lerp(pctAhorroIngresos, 0, 10, 20, 65)
+      : 0;
 
-    // ── 4. Endeudamiento ─────────────────────────────────────────────────────────
-    // Suma cuotas mensuales de préstamos activos (no simulación)
+    // ── 4. Endeudamiento — excluye préstamos ya finalizados ──────────────────────
+    const today = new Date().toISOString().slice(0,10);
     const cuotasTotales = loans
-      .filter(l => l.activo && !l.simulacion)
+      .filter(l => {
+        if (!l.activo || l.simulacion) return false;
+        const { tabla } = FinanceMath.resumenPrestamo(l);
+        const ultimaCuota = tabla.filter(r => !r.esAmortizacion).slice(-1)[0];
+        return ultimaCuota && ultimaCuota.fecha >= today; // excluye finalizados
+      })
       .reduce((s, l) => s + FinanceMath.cuotaMensual(l.capital, l.tin, l.meses), 0);
     const pctDeudaIngresos = ingresosMes > 0 ? (cuotasTotales / ingresosMes) * 100 : null;
-    // Ratios convencionales: <20% excelente, <35% aceptable, ≥35% alerta
     const colorDeuda = cuotasTotales === 0 ? '#00e5a0'
       : pctDeudaIngresos === null ? 'var(--text3)'
-      : pctDeudaIngresos < 20 ? '#00e5a0'
-      : pctDeudaIngresos < 35 ? '#ffd166'
-      : '#ff4d6d';
-    const labelDeuda = cuotasTotales === 0 ? 'Sin préstamos'
+      : pctDeudaIngresos < 20 ? '#00e5a0' : pctDeudaIngresos < 35 ? '#ffd166' : '#ff4d6d';
+    const labelDeuda = cuotasTotales === 0 ? 'Sin préstamos activos'
       : pctDeudaIngresos === null ? '—'
-      : pctDeudaIngresos < 20 ? 'Excelente'
-      : pctDeudaIngresos < 35 ? 'Aceptable'
-      : 'Elevado ⚠️';
+      : pctDeudaIngresos < 20 ? 'Excelente' : pctDeudaIngresos < 35 ? 'Aceptable' : 'Elevado ⚠️';
+    const scoreDeuda = cuotasTotales === 0 ? 100
+      : pctDeudaIngresos === null ? 50
+      : pctDeudaIngresos < 15  ? 100
+      : pctDeudaIngresos < 35  ? lerp(pctDeudaIngresos, 15, 35, 95, 45)
+      : pctDeudaIngresos < 50  ? lerp(pctDeudaIngresos, 35, 50, 45, 10)
+      : 0;
 
-    // ── Score global simplificado (para exec summary) ────────────────────────────
-    // Promedio de semáforos: verde=100, amarillo=50, rojo=0, gris=50 (sin datos)
-    const semToVal = (col) => col === '#00e5a0' ? 100 : col === '#ffd166' ? 50 : col === '#ff4d6d' ? 0 : 50;
-    const total = Math.round((semToVal(colorFijos) + semToVal(colorBasicos) + semToVal(colorAhorro) + semToVal(colorDeuda)) / 4);
+    // ── Score global con pesos: ahorro 40%, deuda 35%, gastos fijos 25% ──────────
+    const total = Math.round(scoreAhorro * 0.40 + scoreDeuda * 0.35 + scoreFijos * 0.25);
     const label = total >= 80 ? 'Excelente' : total >= 60 ? 'Buena' : total >= 40 ? 'Regular' : 'Atención';
     const color = total >= 80 ? '#00e5a0' : total >= 60 ? '#4d9fff' : total >= 40 ? '#ffd166' : '#ff4d6d';
 
@@ -678,9 +683,7 @@ const FinanceMath = (() => {
         fijos: {
           label: 'Gastos fijos',
           valor: eur(gastosFijosMes) + '/mes',
-          pcts: [
-            pctFijosIngresos !== null ? `${pctFijosIngresos.toFixed(1)}% de ingresos` : 'Sin ingresos registrados',
-          ],
+          pcts: [pctFijosIngresos !== null ? `${pctFijosIngresos.toFixed(1)}% de ingresos` : 'Sin ingresos registrados'],
           color: colorFijos,
           rec: gastosFijosMes === 0
             ? 'Registra tus gastos mensuales recurrentes para activar esta métrica.'
@@ -688,7 +691,7 @@ const FinanceMath = (() => {
             ? '✅ Tus gastos fijos son una proporción saludable de tus ingresos.'
             : pctFijosIngresos < 60
             ? '💡 Revisa si algún gasto fijo puede eliminarse o convertirse en variable (suscripciones, seguros...).'
-            : '⚠️ Más del 60% de tus ingresos está comprometido en gastos fijos. Ante una bajada de ingresos tendrías muy poco margen.',
+            : '⚠️ Más del 60% de tus ingresos comprometido en gastos fijos. Ante una bajada de ingresos tendrías muy poco margen.',
         },
         basicos: {
           label: 'Gastos básicos',
@@ -701,43 +704,38 @@ const FinanceMath = (() => {
           rec: gastosBasicosMes === 0
             ? 'Marca tus gastos esenciales como "básico" en la sección Gastos para activar esta métrica.'
             : pctBasicosSobreFijos > 70
-            ? '✅ La mayoría de tus gastos fijos son básicos. Tu presupuesto tiene una base sólida de necesidades reales.'
+            ? '✅ La mayoría de tus gastos fijos son básicos. Tu presupuesto tiene una base sólida.'
             : pctBasicosSobreFijos > 40
             ? '💡 Parte de tus gastos fijos son discrecionales. Revisa si todos son realmente necesarios.'
-            : '⚠️ Menos del 40% de tus gastos fijos son básicos. Tienes un alto componente discrecional en tu presupuesto fijo.',
+            : '⚠️ Menos del 40% de tus gastos fijos son básicos. Alto componente discrecional.',
         },
         ahorro: {
           label: 'Ahorro mensual esperado',
           valor: eur(ahorroMes) + '/mes',
-          pcts: [
-            pctAhorroIngresos !== null ? `${pctAhorroIngresos.toFixed(1)}% de ingresos` : 'Sin ingresos registrados',
-          ],
+          pcts: [pctAhorroIngresos !== null ? `${pctAhorroIngresos.toFixed(1)}% de ingresos` : 'Sin ingresos registrados'],
           color: colorAhorro,
           rec: pctAhorroIngresos === null
             ? 'Registra tus ingresos mensuales para activar esta métrica.'
-            : ahorroMes > 0 && pctAhorroIngresos > 20
+            : ahorroMes > 0 && pctAhorroIngresos >= 20
             ? '✅ Ahorras más del 20% de tus ingresos. Considera invertir el excedente.'
             : ahorroMes > 0
-            ? '💡 Tu tasa de ahorro es baja. Intenta reducir gastos variables para llegar al 20%.'
+            ? '💡 Tasa de ahorro baja. Objetivo recomendado: 20% de los ingresos.'
             : '⚠️ Tus gastos superan tus ingresos en la proyección. Revisa tus gastos recurrentes urgentemente.',
         },
         deuda: {
           label: 'Endeudamiento',
-          valor: cuotasTotales > 0 ? eur(cuotasTotales) + '/mes' : 'Sin préstamos',
-          pcts: cuotasTotales > 0 ? [
-            pctDeudaIngresos !== null ? `${pctDeudaIngresos.toFixed(1)}% de ingresos · ${labelDeuda}` : '—',
-          ] : [],
+          valor: cuotasTotales > 0 ? eur(cuotasTotales) + '/mes' : 'Sin préstamos activos',
+          pcts: cuotasTotales > 0 && pctDeudaIngresos !== null ? [`${pctDeudaIngresos.toFixed(1)}% de ingresos · ${labelDeuda}`] : [],
           color: colorDeuda,
           rec: cuotasTotales === 0
-            ? '✅ No tienes préstamos activos.'
+            ? '✅ No tienes préstamos activos en curso.'
             : pctDeudaIngresos < 20
-            ? '✅ Ratio de deuda excelente (<20%). Tus cuotas son una carga muy manejable.'
+            ? '✅ Ratio de deuda excelente (<20%). Cuotas muy manejables.'
             : pctDeudaIngresos < 35
-            ? '💡 Ratio aceptable (20-35%). Dentro de los umbrales bancarios estándar, pero hay margen de mejora con amortizaciones anticipadas.'
-            : '⚠️ Ratio de deuda elevado (>35%). Los bancos suelen rechazar nuevos créditos por encima de este umbral. Prioriza reducir deuda.',
+            ? '💡 Ratio aceptable (20-35%). Dentro de umbrales bancarios estándar. Las amortizaciones anticipadas pueden mejorar este ratio.'
+            : '⚠️ Ratio de deuda elevado (>35%). Los bancos suelen rechazar nuevos créditos por encima de este umbral.',
         },
       },
-      // mantener backward-compat con exec summary
       breakdown: {}
     };
   }
@@ -822,16 +820,20 @@ const FinanceMath = (() => {
     }
 
     // ── Bucle principal ─────────────────────────────────────────────────────────
+    // Buffer de seguridad para absorber redondeos y evitar bajar del colchón
+    const SAFETY_BUFFER = 2;
+
     for (let i = 0; i < horizonte; i++) {
       if (i % frecuencia !== 0) continue;
 
       const { label, ini, fin, dia15 } = mesInfo(i);
 
       const saldoMin  = saldoMinDelMes(ini, fin);
-      const excedente = saldoMin - colchon;
+      const excedente = saldoMin - colchon - SAFETY_BUFFER;
       if (excedente < minAmortizable) continue;
 
       let excedentRestante = excedente;
+      let totalAmortizadoEsteMes = 0;
 
       for (const loan of loansActivos) {
         if (excedentRestante < minAmortizable) break;
@@ -841,28 +843,30 @@ const FinanceMath = (() => {
 
         const comAmort     = loan.comisionAmort || 0;
         const factorCom    = 1 + comAmort / 100;
-        const maxAmortNeto = excedentRestante / factorCom;
+        const maxAmortNeto = Math.floor(excedentRestante / factorCom);
         const cantidadF    = Math.min(maxAmortNeto, capActual);
         if (cantidadF < minAmortizable) continue;
 
-        // Nunca amortizar más de lo que queda (ambos truncados a entero para evitar
-        // errores de punto flotante cuando capActual tiene decimales)
         const cantidad   = Math.min(Math.floor(cantidadF), Math.floor(capActual));
         const comision   = +(cantidad * comAmort / 100).toFixed(2);
         const costeTotal = cantidad + comision;
+
+        // Verificación final: el coste no puede superar el excedente restante
+        if (costeTotal > excedentRestante) continue;
 
         amortsPorLoan[loan._id].push({
           _id: `opt_${label}_${loan._id}`,
           fecha: dia15, cantidad, tipo: tipoAmort, simulacion: true,
         });
 
+        totalAmortizadoEsteMes += costeTotal;
         plan.push({
           mes: label, fechaAmort: dia15,
           loanId: loan._id, loanNombre: loan.nombre, tin: loan.tin,
           capitalAntes: capActual, cantidadAmort: cantidad, comision,
           capitalDespues: Math.max(0, capActual - cantidad),
           saldoMin, excedente,
-          saldoDespuesMes: saldoMin - costeTotal,
+          saldoDespuesMes: saldoMin - totalAmortizadoEsteMes, // acumulado correcto
           tipoAmort,
         });
 
@@ -1015,6 +1019,6 @@ const FinanceMath = (() => {
   function eur(n) { return new Intl.NumberFormat('es-ES',{style:'currency',currency:'EUR'}).format(n||0); }
   function pct(n) { return (n||0).toFixed(2)+'%'; }
 
-  return { saldoRealCuenta, calcFondosPension, calcImpuestoPension, cuotaMensual, calcTAE, tablaAmortizacion, resumenPrestamo, resumenPrestamoConAhorro, proyectarGastos, proyectarTransferencias, proyectarPrestamos, generarExtracto, saldoHoy, agruparOHLC, sumarPorTags, mediaMensualGastos, calcColchon, aplicarInflacion, calcIRPF, retencionMensual, proyectarRetencionesFiscales, detectarPuntosCriticos, monteCarlo, calcScore, calcDesviacion, optimizarAmortizaciones, compararFrecuencias, resolverDiaEfectivo, ajustarFechaPago, labelDiaPago, eur, pct };
+  return { saldoRealCuenta, calcFondosPension, calcImpuestoPension, cuotaMensual, calcTAE, tablaAmortizacion, resumenPrestamo, resumenPrestamoConAhorro, proyectarGastos, proyectarTransferencias, proyectarPrestamos, generarExtracto, saldoHoy, agruparOHLC, sumarPorTags, mediaMensualGastos, calcColchon, calcGastoBasicoMensual, aplicarInflacion, calcIRPF, retencionMensual, proyectarRetencionesFiscales, detectarPuntosCriticos, monteCarlo, calcScore, calcDesviacion, optimizarAmortizaciones, compararFrecuencias, resolverDiaEfectivo, ajustarFechaPago, labelDiaPago, eur, pct };
 })();
 

--- a/loans/loans.js
+++ b/loans/loans.js
@@ -1,32 +1,46 @@
 // Depends on: State, FinanceMath, UI
 const LoansModule = (() => {
+  let mostrarFinalizados = false;
+
+  function isLoanCompleted(loan) {
+    if (!loan.activo || loan.simulacion) return false;
+    const today = new Date().toISOString().slice(0,10);
+    const { tabla } = FinanceMath.resumenPrestamo(loan);
+    const regularRows = tabla.filter(r => !r.esAmortizacion);
+    if (regularRows.length === 0) return true;
+    return regularRows[regularRows.length - 1].fecha < today;
+  }
 
   function render(keepOpen=null) {
-    // Preserve which loan bodies are currently open
     const view = document.getElementById('view-loans');
     const openIds = keepOpen ?? [...view.querySelectorAll('.loan-card-body.open')].map(el => el.id.replace('loan-body-',''));
-    const loans = [...State.get('loans')].sort((a,b)=>b.tin-a.tin);
+    const allLoans = [...State.get('loans')].sort((a,b)=>b.tin-a.tin);
 
-    // ── Cuota del mes actual por préstamo activo ──────────────────────────────
+    // Classify
+    const completedIds = new Set(allLoans.filter(l => isLoanCompleted(l)).map(l => l._id));
+    const loans = mostrarFinalizados ? allLoans : allLoans.filter(l => !completedIds.has(l._id));
+    const numFinalizados = completedIds.size;
+
+    // ── Cuota del mes actual — solo préstamos activos y no finalizados ────────
     const hoy = new Date();
     const mesActual = `${hoy.getFullYear()}-${String(hoy.getMonth()+1).padStart(2,'0')}`;
     let totalCuotaMes = 0;
-    const cuotaMesMap = {}; // _id → cuota del mes actual (0 si no hay)
-    loans.filter(l => l.activo && !l.simulacion).forEach(loan => {
+    const cuotaMesMap = {};
+    allLoans.filter(l => l.activo && !l.simulacion && !completedIds.has(l._id)).forEach(loan => {
       const { tabla } = FinanceMath.resumenPrestamo(loan);
-      // Buscar filas normales (no amortización) cuya fecha cae en el mes actual
       const filasMes = tabla.filter(r => !r.esAmortizacion && r.fecha.startsWith(mesActual));
       const cuota = filasMes.length > 0 ? filasMes[0].cuota : 0;
       cuotaMesMap[loan._id] = cuota;
       totalCuotaMes += cuota;
     });
 
-    const activosConCuota = loans.filter(l => l.activo && !l.simulacion && cuotaMesMap[l._id] > 0).length;
+    const activosConCuota = allLoans.filter(l => l.activo && !l.simulacion && !completedIds.has(l._id) && cuotaMesMap[l._id] > 0).length;
 
     view.innerHTML = `
       <div class="page-header">
         <h1 class="page-title">Mis <span>Préstamos</span></h1>
         <div class="page-actions">
+          ${numFinalizados > 0 ? `<button class="btn-secondary btn-sm" onclick="LoansModule.toggleFinalizados()">${mostrarFinalizados?'Ocultar':'Mostrar'} finalizados (${numFinalizados})</button>` : ''}
           <button class="btn-secondary" id="btn-optimizar">✨ Optimizar amortizaciones</button>
           <button class="btn-primary" id="btn-new-loan">+ Nuevo préstamo</button>
         </div>
@@ -36,13 +50,13 @@ const LoansModule = (() => {
         <div class="flex gap-24 items-center flex-wrap">
           <div>
             <div class="stat-label">Cuotas este mes (${hoy.toLocaleDateString('es-ES',{month:'long',year:'numeric'})})</div>
-            <div style="font-family:var(--font-mono);font-size:24px;font-weight:700;color:var(--red);margin-top:2px">${FinanceMath.eur(totalCuotaMes)}</div>
+            <div style="font-family:var(--font-mono);font-size:24px;font-weight:700;color:var(--text);margin-top:2px">${FinanceMath.eur(totalCuotaMes)}</div>
           </div>
-          <div class="text-sm" style="color:var(--text3)">${activosConCuota} préstamo${activosConCuota!==1?'s':''} con cuota en este mes</div>
+          <div class="text-sm" style="color:var(--text3)">${activosConCuota} préstamo${activosConCuota!==1?'s':''} con cuota activa este mes</div>
         </div>
       </div>` : ''}
       <div id="loans-list">
-        ${loans.length===0?'<div class="text-sm" style="text-align:center;padding:40px 0">Sin préstamos.</div>':loans.map(l=>renderCard(l, cuotaMesMap[l._id]||0)).join('')}
+        ${loans.length===0?'<div class="text-sm" style="text-align:center;padding:40px 0">Sin préstamos.</div>':loans.map(l=>renderCard(l, cuotaMesMap[l._id]||0, completedIds.has(l._id))).join('')}
       </div>`;
     document.getElementById('btn-new-loan').onclick = () => openForm();
     document.getElementById('btn-optimizar').onclick = () => openOptimizador();
@@ -58,7 +72,9 @@ const LoansModule = (() => {
     });
   }
 
-  function renderCard(loan, cuotaMes=0) {
+  function toggleFinalizados() { mostrarFinalizados = !mostrarFinalizados; render(); }
+
+  function renderCard(loan, cuotaMes=0, completado=false) {
     const res = FinanceMath.resumenPrestamoConAhorro(loan);
     const tieneAmorts = (loan.amortizaciones||[]).length > 0;
     const diaPagoLabel = FinanceMath.labelDiaPago(loan.diaPago||'');
@@ -72,10 +88,11 @@ const LoansModule = (() => {
     const interesesActual   = res.totalIntereses;
     const interesesOriginal = res.sinAmort.totalIntereses;
 
-    return `<div class="loan-card" id="loan-${loan._id}">
+    return `<div class="loan-card" id="loan-${loan._id}" style="${completado?'opacity:0.65':''}">
       <div class="loan-card-header" data-loan-id="${loan._id}">
         <div class="flex gap-8 items-center" style="flex-wrap:wrap">
           <span class="loan-card-title">${loan.nombre}</span>
+          ${completado?'<span class="badge badge-active" style="background:rgba(0,229,160,0.15);color:var(--accent)">✓ Finalizado</span>':''}
           ${loan.simulacion?'<span class="badge badge-sim">SIM</span>':''}
           ${!loan.activo?'<span class="badge badge-inactive">Inactivo</span>':''}
           <span class="badge badge-blue">${State.accountName(loan.cuenta||'default')}</span>
@@ -610,5 +627,5 @@ const LoansModule = (() => {
     render(Object.keys(porLoan));
   }
 
-  return { render, saveLoan, deleteAmort, openAmortForm, saveAmort, openOptimizador, runOptimizador, runComparador, aplicarDesdeComparador, aplicarPlanOptimizado };
+  return { render, saveLoan, deleteAmort, openAmortForm, saveAmort, openOptimizador, runOptimizador, runComparador, aplicarDesdeComparador, aplicarPlanOptimizado, toggleFinalizados };
 })();

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -12,8 +12,20 @@ const UI = (() => {
     const opts=options.map(([v,l])=>`<option value="${v}"${v==value?' selected':''}>${l}</option>`).join('');
     return `<div class="form-group"><label class="form-label" for="${id}">${label}</label><select class="form-select" id="${id}">${opts}</select></div>`;
   }
-  function accountSelect(id, label, value='default') {
-    return select(id, label, State.accountOptions(), value||'default');
+  function accountSelect(id, label, value='') {
+    const accounts = State.get('accounts') || [];
+    const principalId = State.getPrincipalAccountId();
+    const useValue = value || principalId;
+    const sorted = [...accounts].sort((a, b) => {
+      if (a.esCuentaPrincipal && !b.esCuentaPrincipal) return -1;
+      if (!a.esCuentaPrincipal && b.esCuentaPrincipal) return 1;
+      return a.nombre.localeCompare(b.nombre);
+    });
+    const opts = sorted.map(a => [
+      a._id,
+      a.nombre + (a.simulacion ? ' (SIM)' : '') + (a.esCuentaPrincipal ? ' ★' : '')
+    ]);
+    return select(id, label, opts, useValue);
   }
 
   // ── Widget día efectivo ────────────────────────────────────────────────────


### PR DESCRIPTION
- Cuentas: cualquier cuenta puede marcarse como Principal (★), usada por defecto en
  nuevos gastos/préstamos. La antigua cuenta "Default" puede renombrarse y eliminarse.
- UX colores: eliminados falsos alarmas en rojo/amarillo en paneles de gastos, cuotas y
  resumen ejecutivo; cuotas del mes en color neutro; gráfico breakdown usa púrpura para
  cuotas en lugar de amarillo.
- Resumen ejecutivo: sustituye "media gastos/mes" por "ahorro est./mes" (±), añade
  "Ingresos/mes" y muestra el colchón como cubierto/no cubierto con indicador visual.
- Amortizaciones: añadido buffer de seguridad (€2) para no bajar del umbral; corregido
  saldoDespuesMes acumulado en meses con varias amortizaciones; verificación final por
  préstamo. Score excluye préstamos finalizados del ratio de deuda.
- Periodo fin: selector rápido 1M/3M/6M/1Y/5Y/10Y que rellena el input de fecha y aplica.
- Colchón económico: toggle "Por meses" / "Cantidad fija"; recomendación contextual basada
  en gastos básicos reales y best-practices (3-6 meses).
- Score: puntuación continua con pesos (ahorro 40%, deuda 35%, gastos fijos 25%) en lugar
  de semáforos binarios; el ratio de deuda excluye préstamos ya finalizados.
- Préstamos: detección automática de préstamos finalizados (últimas cuotas en el pasado);
  botón "Mostrar/Ocultar finalizados"; excluidos del cálculo de cuotas activas del mes.

https://claude.ai/code/session_01Hodt2kp8jBwtUSZLytVJxT