### PR TITLE
feat: distribución necesidad/deseo en salud financiera

### DIFF
--- a/src/v2/app.css
+++ b/src/v2/app.css
@@ -1704,3 +1704,149 @@ body {
   text-align: right;
   white-space: nowrap;
 }
+
+/* ── Income distribution widget ───────────────────────────────────────────── */
+
+.db__dist-widget {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.db__dist-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.db__dist-header .db__section-title {
+  margin-bottom: 0;
+}
+
+.db__dist-net {
+  font-size: 20px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.db__dist-net-unit {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  margin-left: 4px;
+}
+
+.db__dist-irpf-row {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.db__dist-mode {
+  font-style: italic;
+}
+
+.db__dist-bar {
+  display: flex;
+  height: 14px;
+  border-radius: 7px;
+  overflow: hidden;
+  background: var(--bg-elevated);
+  gap: 2px;
+}
+
+.db__dist-bar--deficit {
+  outline: 2px solid var(--accent-red);
+  outline-offset: 1px;
+}
+
+.db__dist-seg {
+  height: 100%;
+  transition: width 0.4s ease;
+  min-width: 2px;
+}
+
+.db__dist-seg--necesidad {
+  background: var(--accent-blue);
+  border-radius: 7px 0 0 7px;
+}
+
+.db__dist-seg--deseo {
+  background: var(--accent-yellow);
+}
+
+.db__dist-seg--ahorro {
+  background: var(--accent-green);
+  border-radius: 0 7px 7px 0;
+  flex: 1;
+}
+
+.db__dist-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.db__dist-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.db__dist-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.db__dist-legend-label {
+  flex: 1;
+  color: var(--text-primary);
+}
+
+.db__dist-legend-amount {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.db__dist-legend-pct {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  min-width: 46px;
+  text-align: right;
+}
+
+.db__dist-unclassified {
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 8px 12px;
+  background: var(--bg-elevated);
+  border-radius: 6px;
+  border-left: 3px solid var(--accent-yellow);
+}
+
+/* ── Clasificación badges ──────────────────────────────────────────────────── */
+
+.exp-badge--necesidad {
+  background: color-mix(in srgb, var(--accent-blue) 18%, transparent);
+  color: var(--accent-blue);
+}
+
+.exp-badge--deseo {
+  background: color-mix(in srgb, var(--accent-yellow) 18%, transparent);
+  color: var(--accent-yellow);
+}
+
+.exp-badge--sin-clasificar {
+  background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+  color: var(--text-secondary);
+}

--- a/src/v2/finance-math/finance-math.ts
+++ b/src/v2/finance-math/finance-math.ts
@@ -14,6 +14,7 @@ import type {
   EmergencyFundStatus,
   BudgetProgress,
   FiscalProjection,
+  DistribucionNecesidadDeseo,
   ScenarioParams,
   ScenarioPoint,
 } from '@/types/domain';
@@ -1201,6 +1202,68 @@ export function calculateFiscalProjection(
     pensionContribuidoAnyo,
     margenDeduccionPension,
     ahorroFiscalPension,
+  };
+}
+
+// ── Income distribution: necesidad / deseo ────────────────────────────────────
+
+/**
+ * Calculates the distribution of net income into necesidad, deseo and ahorro.
+ * Net income = gross monthly income − monthly IRPF (or gross if no brackets).
+ * Expenses without clasificacion are excluded from the computation.
+ */
+export function calculateDistribucionNecesidadDeseo(
+  expenses: Expense[],
+  accounts: Account[],
+  config: AppConfig
+): DistribucionNecesidadDeseo {
+  const modoSimplificado = !config.tramos_irpf?.length;
+
+  const ingresosBrutos = expenses
+    .filter((e) => e.activo && e.tipo === 'ingreso' && e.tipoFrecuencia === 'mensual')
+    .reduce((s, e) => s + e.cuantia, 0);
+
+  let irpfMensual = 0;
+  if (!modoSimplificado) {
+    const fiscal = calculateFiscalProjection(expenses, accounts, config);
+    irpfMensual = fiscal.cuotaIRPF / 12;
+  }
+
+  const ingresoNeto = Math.max(0, ingresosBrutos - irpfMensual);
+
+  const gastosActivos = expenses.filter(
+    (e) => e.activo && e.tipo === 'gasto' && e.tipoFrecuencia === 'mensual'
+  );
+
+  const gastoNecesidad = gastosActivos
+    .filter((e) => e.clasificacion === 'necesidad')
+    .reduce((s, e) => s + e.cuantia, 0);
+
+  const gastoDeseo = gastosActivos
+    .filter((e) => e.clasificacion === 'deseo')
+    .reduce((s, e) => s + e.cuantia, 0);
+
+  const gastoNoClasificado = gastosActivos
+    .filter((e) => !e.clasificacion)
+    .reduce((s, e) => s + e.cuantia, 0);
+
+  const ahorro = ingresoNeto - gastoNecesidad - gastoDeseo;
+  const pctNecesidad = ingresoNeto > 0 ? (gastoNecesidad / ingresoNeto) * 100 : 0;
+  const pctDeseo = ingresoNeto > 0 ? (gastoDeseo / ingresoNeto) * 100 : 0;
+  const pctAhorro = ingresoNeto > 0 ? (ahorro / ingresoNeto) * 100 : 0;
+
+  return {
+    ingresosBrutos,
+    irpfMensual,
+    ingresoNeto,
+    modoSimplificado,
+    gastoNecesidad,
+    gastoDeseo,
+    gastoNoClasificado,
+    ahorro,
+    pctNecesidad,
+    pctDeseo,
+    pctAhorro,
   };
 }
 

--- a/src/v2/test-utils/factories.ts
+++ b/src/v2/test-utils/factories.ts
@@ -51,6 +51,7 @@ export function expenseFactory(overrides: Partial<Expense> = {}): Expense {
     varianza: 0,
     inflacion: 0,
     sujetoIRPF: false,
+    clasificacion: null,
     tags: [],
     ...overrides,
   };

--- a/src/v2/types/domain.ts
+++ b/src/v2/types/domain.ts
@@ -36,6 +36,8 @@ export interface Loan {
 }
 
 // ── Expense / Income / Transfer ─────────────────────────────────────────────
+export type ClasificacionGasto = 'necesidad' | 'deseo' | null;
+
 export interface Expense {
   _id: string;
   concepto: string;
@@ -53,6 +55,7 @@ export interface Expense {
   varianza: number; // % variance for Monte Carlo (0 = deterministic)
   inflacion: number; // Annual inflation % (0 = use global config)
   sujetoIRPF: boolean;
+  clasificacion: ClasificacionGasto; // null = unclassified (excluded from distribution)
   tags: string[];
 }
 
@@ -293,6 +296,21 @@ export interface FiscalProjection {
   pensionContribuidoAnyo: number; // sum of pension contributions this year
   margenDeduccionPension: number; // limiteDeduccionPension - pensionContribuidoAnyo
   ahorroFiscalPension: number; // margen × tipoMarginal / 100
+}
+
+// ── Income distribution (necesidad / deseo) ──────────────────────────────────
+export interface DistribucionNecesidadDeseo {
+  ingresosBrutos: number; // sum of active monthly income
+  irpfMensual: number; // monthly IRPF (0 when modoSimplificado)
+  ingresoNeto: number; // ingresosBrutos - irpfMensual
+  modoSimplificado: boolean; // true when no IRPF brackets configured
+  gastoNecesidad: number; // monthly spend classified as necesidad
+  gastoDeseo: number; // monthly spend classified as deseo
+  gastoNoClasificado: number; // monthly spend without classification (excluded)
+  ahorro: number; // ingresoNeto - gastoNecesidad - gastoDeseo
+  pctNecesidad: number; // % of ingresoNeto
+  pctDeseo: number; // % of ingresoNeto
+  pctAhorro: number; // % of ingresoNeto (negative = deficit)
 }
 
 // ── Multi-scenario forecast (#25) ─────────────────────────────────────────────

--- a/src/v2/views/DashboardView.ts
+++ b/src/v2/views/DashboardView.ts
@@ -8,12 +8,14 @@ import {
   calculateFinancialScore,
   calculateEmergencyFundStatus,
   detectCriticalPoints,
+  calculateDistribucionNecesidadDeseo,
 } from '@/finance-math/finance-math';
 import type {
   StatementEntry,
   CriticalPoint,
   FinancialScore,
   EmergencyFundStatus,
+  DistribucionNecesidadDeseo,
 } from '@/types/domain';
 
 const eur = (n: number) =>
@@ -53,6 +55,7 @@ export class DashboardView extends BaseComponent {
     const score = calculateFinancialScore(statement, loans, expenses, accounts, config);
     const ef = calculateEmergencyFundStatus(expenses, accounts, config);
     const criticals = detectCriticalPoints(statement, cushion);
+    const dist = calculateDistribucionNecesidadDeseo(expenses, accounts, config);
 
     const today = new Date().toISOString().slice(0, 10);
     const in30 = new Date(Date.now() + 30 * 86400000).toISOString().slice(0, 10);
@@ -81,6 +84,8 @@ export class DashboardView extends BaseComponent {
             <div class="kpi-card__badge" style="color:${scoreColor}">${score.label}</div>
           </div>
         </div>
+
+        ${dist.ingresosBrutos > 0 ? distribucionWidget(dist) : ''}
 
         ${score.ingresosMes > 0 ? scoreDetail(score) : ''}
 
@@ -299,6 +304,99 @@ function eventRow(ev: StatementEntry): string {
       <span class="ev-row__label">${ev.concepto}</span>
       <span class="ev-row__delta ev-row__delta--${cls}">${sign}${eur2(ev.delta)}</span>
       <span class="ev-row__balance">${eur2(ev.saldoAcum)}</span>
+    </div>`;
+}
+
+// ── Distribution widget helpers ───────────────────────────────────────────────
+
+function distLegendItem(color: string, label: string, amount: number, pct: number): string {
+  return `
+    <div class="db__dist-legend-item">
+      <span class="db__dist-dot" style="background:${color}"></span>
+      <span class="db__dist-legend-label">${label}</span>
+      <span class="db__dist-legend-amount">${eur(amount)}/mes</span>
+      <span class="db__dist-legend-pct" style="color:${color}">${pct.toFixed(1)}%</span>
+    </div>`;
+}
+
+function distribucionWidget(dist: DistribucionNecesidadDeseo): string {
+  const {
+    ingresoNeto,
+    ingresosBrutos,
+    irpfMensual,
+    modoSimplificado,
+    gastoNecesidad,
+    gastoDeseo,
+    gastoNoClasificado,
+    ahorro,
+    pctNecesidad,
+    pctDeseo,
+    pctAhorro,
+  } = dist;
+
+  const isDeficit = ahorro < 0;
+
+  // Bar segment widths — always relative to ingresoNeto (100%)
+  let wNecesidad = 0;
+  let wDeseo = 0;
+  let wAhorro = 0;
+  if (ingresoNeto > 0) {
+    if (!isDeficit) {
+      wNecesidad = pctNecesidad;
+      wDeseo = pctDeseo;
+      wAhorro = pctAhorro;
+    } else {
+      // Scale necesidad + deseo to fill 100% when in deficit
+      const total = pctNecesidad + pctDeseo;
+      const scale = total > 0 ? 100 / total : 0;
+      wNecesidad = pctNecesidad * scale;
+      wDeseo = pctDeseo * scale;
+    }
+  }
+
+  const irpfRow = modoSimplificado
+    ? `<span class="db__dist-mode">Sin retención IRPF (modo simplificado)</span>`
+    : `<span class="db__dist-irpf">Bruto ${eur(ingresosBrutos)}/mes · IRPF estimado ${eur(irpfMensual)}/mes</span>`;
+
+  const ahorroColor = ahorro >= 0 ? 'var(--accent-green)' : 'var(--accent-red)';
+  const ahorroLabel = ahorro >= 0 ? 'Ahorro estimado' : 'Déficit';
+
+  const ahorroRow = `
+    <div class="db__dist-legend-item">
+      <span class="db__dist-dot" style="background:${ahorroColor}"></span>
+      <span class="db__dist-legend-label">${ahorroLabel}</span>
+      <span class="db__dist-legend-amount" style="color:${ahorroColor}">${ahorro >= 0 ? '' : '−'}${eur(Math.abs(ahorro))}/mes</span>
+      <span class="db__dist-legend-pct" style="color:${ahorroColor}">${Math.abs(pctAhorro).toFixed(1)}%</span>
+    </div>`;
+
+  const unclassifiedNote =
+    gastoNoClasificado > 0
+      ? `<div class="db__dist-unclassified">
+          ⚠ ${eur(gastoNoClasificado)}/mes en gastos sin clasificar — no se incluyen en el cómputo
+        </div>`
+      : '';
+
+  return `
+    <div class="db__dist-widget">
+      <div class="db__dist-header">
+        <h2 class="db__section-title">Distribución de ingresos</h2>
+        <span class="db__dist-net">${eur(ingresoNeto)}<span class="db__dist-net-unit">/mes neto</span></span>
+      </div>
+      <div class="db__dist-irpf-row">${irpfRow}</div>
+
+      <div class="db__dist-bar${isDeficit ? ' db__dist-bar--deficit' : ''}">
+        <div class="db__dist-seg db__dist-seg--necesidad" style="width:${wNecesidad.toFixed(1)}%"></div>
+        <div class="db__dist-seg db__dist-seg--deseo" style="width:${wDeseo.toFixed(1)}%"></div>
+        ${!isDeficit && wAhorro > 0.1 ? `<div class="db__dist-seg db__dist-seg--ahorro" style="width:${wAhorro.toFixed(1)}%"></div>` : ''}
+      </div>
+
+      <div class="db__dist-legend">
+        ${distLegendItem('var(--accent-blue)', 'Necesidades', gastoNecesidad, pctNecesidad)}
+        ${distLegendItem('var(--accent-yellow)', 'Deseos', gastoDeseo, pctDeseo)}
+        ${ahorroRow}
+      </div>
+
+      ${unclassifiedNote}
     </div>`;
 }
 

--- a/src/v2/views/ExpenseListView.ts
+++ b/src/v2/views/ExpenseListView.ts
@@ -146,6 +146,14 @@ export class ExpenseListView extends BaseComponent {
       : '';
     const basicBadge = exp.basico ? '<span class="exp-badge exp-badge--basic">básico</span>' : '';
     const irpfBadge = exp.sujetoIRPF ? '<span class="exp-badge exp-badge--irpf">IRPF</span>' : '';
+    const clasificacionBadge =
+      exp.tipo === 'gasto'
+        ? exp.clasificacion === 'necesidad'
+          ? '<span class="exp-badge exp-badge--necesidad">necesidad</span>'
+          : exp.clasificacion === 'deseo'
+            ? '<span class="exp-badge exp-badge--deseo">deseo</span>'
+            : '<span class="exp-badge exp-badge--sin-clasificar">sin clasificar</span>'
+        : '';
 
     return `
       <div class="exp-row">
@@ -160,7 +168,7 @@ export class ExpenseListView extends BaseComponent {
           <div class="exp-row__meta">
             <span class="exp-row__freq">${freqLabel}${freqN}</span>
             <span class="exp-row__account">${accountName(exp.cuenta)}</span>
-            ${basicBadge}${irpfBadge}${tags}
+            ${basicBadge}${irpfBadge}${clasificacionBadge}${tags}
           </div>
         </div>
       </div>`;


### PR DESCRIPTION
## Resumen

- Nuevo campo `clasificacion: 'necesidad' | 'deseo' | null` en `Expense`
- Ingreso neto = nómina bruta − IRPF mensual estimado (o bruto si modo simplificado sin tramos)
- Gastos sin clasificar (`null`) excluidos del cómputo y del ahorro
- Widget "Distribución de ingresos" en Dashboard: barra apilada NECESIDAD / DESEO / AHORRO con indicador de déficit
- Badges de clasificación en la lista de gastos

## Test plan

- [ ] 107 tests pasan (`npm test`)
- [ ] Dashboard muestra widget con barra apilada cuando hay ingresos configurados
- [ ] Gastos sin clasificar aparecen con badge "sin clasificar" y aviso en el widget
- [ ] Con tramos IRPF configurados, el widget descuenta la retención mensual estimada
- [ ] Sin tramos IRPF, el widget muestra "modo simplificado"

https://claude.ai/code/session_01VfmarvaWJP8Kv6GqUPkA3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfmarvaWJP8Kv6GqUPkA3g)_