### PR TITLE
feat: menú contextual de clasificación + fix responsive filas de gasto

### DIFF
--- a/src/v2/app.css
+++ b/src/v2/app.css
@@ -668,15 +668,22 @@ body {
   overflow: hidden;
 }
 
+.exp-entry {
+  border-bottom: 1px solid var(--border);
+}
+
+.exp-entry:last-child {
+  border-bottom: none;
+}
+
+.exp-entry--open .exp-row {
+  background: var(--bg-elevated);
+}
+
 .exp-row {
   display: flex;
   align-items: stretch;
-  border-bottom: 1px solid var(--border);
   transition: background var(--transition);
-}
-
-.exp-row:last-child {
-  border-bottom: none;
 }
 
 .exp-row:hover {
@@ -684,7 +691,7 @@ body {
 }
 
 .exp-row__type {
-  width: 90px;
+  width: 84px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -698,15 +705,17 @@ body {
 
 .exp-row__body {
   flex: 1;
-  padding: 10px 14px;
+  padding: 10px 12px;
   min-width: 0;
 }
 
 .exp-row__top {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: baseline;
+  gap: 8px;
   margin-bottom: 4px;
+  min-width: 0;
 }
 
 .exp-row__name {
@@ -716,32 +725,122 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-right: 12px;
+  min-width: 0;
 }
 
 .exp-row__amount {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
   font-family: var(--font-mono);
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .exp-row__meta {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   flex-wrap: wrap;
+  row-gap: 4px;
 }
 
 .exp-row__freq,
 .exp-row__account {
   font-size: 11px;
   color: var(--text-secondary);
+  white-space: nowrap;
 }
 
 .exp-row__account::before {
   content: '·';
-  margin-right: 8px;
+  margin-right: 6px;
+}
+
+.exp-row__menu-btn {
+  width: 36px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-left: 1px solid var(--border);
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  transition: background var(--transition), color var(--transition);
+  padding: 0;
+}
+
+.exp-row__menu-btn:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.exp-entry--open .exp-row__menu-btn {
+  color: var(--accent-blue);
+  background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+}
+
+/* ── Expense context menu ─────────────────────────────────────────────────── */
+
+.exp-menu {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px 8px 84px;
+  background: var(--bg-elevated);
+  border-top: 1px solid var(--border);
+  flex-wrap: wrap;
+  row-gap: 6px;
+}
+
+.exp-menu__label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.exp-menu__actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.exp-menu__btn {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.exp-menu__btn:hover {
+  border-color: var(--text-secondary);
+  color: var(--text-primary);
+}
+
+.exp-menu__btn--active {
+  border-color: currentColor;
+}
+
+.exp-menu__btn--necesidad {
+  background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+  color: var(--accent-blue);
+}
+
+.exp-menu__btn--deseo {
+  background: color-mix(in srgb, var(--accent-yellow) 15%, transparent);
+  color: var(--accent-yellow);
 }
 
 .exp-badge {
@@ -774,8 +873,38 @@ body {
     grid-template-columns: repeat(2, 1fr);
   }
   .exp-row__type {
-    width: 70px;
+    width: 60px;
     font-size: 10px;
+  }
+  .exp-menu {
+    padding-left: 60px;
+  }
+  .exp-row__body {
+    padding: 8px 8px;
+  }
+  .exp-row__name {
+    font-size: 13px;
+  }
+  .exp-row__amount {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .exp-row__type {
+    width: 48px;
+    font-size: 9px;
+    letter-spacing: 0;
+  }
+  .exp-menu {
+    padding-left: 48px;
+  }
+  .exp-row__top {
+    flex-wrap: wrap;
+  }
+  .exp-row__amount {
+    flex-basis: 100%;
+    font-size: 13px;
   }
 }
 

--- a/src/v2/views/ExpenseListView.ts
+++ b/src/v2/views/ExpenseListView.ts
@@ -1,7 +1,7 @@
 import { BaseComponent } from '@/core/BaseComponent';
-import { appStore } from '@/core/store';
+import { appStore, upsertExpense } from '@/core/store';
 import { calculateBudgetProgress } from '@/finance-math/finance-math';
-import type { Expense, TipoMovimiento, BudgetProgress } from '@/types/domain';
+import type { Expense, TipoMovimiento, BudgetProgress, ClasificacionGasto } from '@/types/domain';
 
 const eur = (n: number) =>
   new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(n);
@@ -25,9 +25,49 @@ const TYPE_COLOR: Record<TipoMovimiento, string> = {
 };
 
 export class ExpenseListView extends BaseComponent {
+  private _openMenuId: string | null = null;
+
   override connectedCallback(): void {
     this.connectStore(appStore);
     super.connectedCallback();
+    this.on('click', (e: MouseEvent) => this._handleClick(e));
+  }
+
+  private _handleClick(e: MouseEvent): void {
+    const target = e.target as HTMLElement;
+
+    // Classification button inside the context menu
+    const classBtn = target.closest<HTMLElement>('[data-classify]');
+    if (classBtn) {
+      e.stopPropagation();
+      const id = classBtn.dataset.expId!;
+      const raw = classBtn.dataset.classify!;
+      const clasificacion: ClasificacionGasto =
+        raw === 'necesidad' ? 'necesidad' : raw === 'deseo' ? 'deseo' : null;
+      const exp = appStore.getState().expenses.find((ex) => ex._id === id);
+      if (exp) {
+        upsertExpense({ ...exp, clasificacion });
+        this._openMenuId = null;
+        // store update triggers invalidate() via subscription
+      }
+      return;
+    }
+
+    // Menu toggle button (⋮)
+    const toggleBtn = target.closest<HTMLElement>('[data-menu-toggle]');
+    if (toggleBtn) {
+      e.stopPropagation();
+      const id = toggleBtn.dataset.menuToggle!;
+      this._openMenuId = this._openMenuId === id ? null : id;
+      this.invalidate();
+      return;
+    }
+
+    // Click outside any open menu → close
+    if (this._openMenuId !== null && !target.closest('[data-exp-menu]')) {
+      this._openMenuId = null;
+      this.invalidate();
+    }
   }
 
   protected template(): string {
@@ -132,9 +172,18 @@ export class ExpenseListView extends BaseComponent {
       <section class="exp-group${muted ? ' exp-group--muted' : ''}">
         <h2 class="exp-group__title">${title} <span class="exp-group__count">${list.length}</span></h2>
         <div class="exp-table">
-          ${list.map((e) => this._row(e, accountName)).join('')}
+          ${list.map((e) => this._entry(e, accountName)).join('')}
         </div>
       </section>`;
+  }
+
+  private _entry(exp: Expense, accountName: (id: string) => string): string {
+    const isOpen = this._openMenuId === exp._id;
+    return `
+      <div class="exp-entry${isOpen ? ' exp-entry--open' : ''}">
+        ${this._row(exp, accountName)}
+        ${isOpen ? this._menu(exp) : ''}
+      </div>`;
   }
 
   private _row(exp: Expense, accountName: (id: string) => string): string {
@@ -154,6 +203,10 @@ export class ExpenseListView extends BaseComponent {
             ? '<span class="exp-badge exp-badge--deseo">deseo</span>'
             : '<span class="exp-badge exp-badge--sin-clasificar">sin clasificar</span>'
         : '';
+    const menuBtn =
+      exp.tipo === 'gasto'
+        ? `<button class="exp-row__menu-btn" data-menu-toggle="${exp._id}" aria-label="Opciones de clasificación">⋮</button>`
+        : '';
 
     return `
       <div class="exp-row">
@@ -170,6 +223,23 @@ export class ExpenseListView extends BaseComponent {
             <span class="exp-row__account">${accountName(exp.cuenta)}</span>
             ${basicBadge}${irpfBadge}${clasificacionBadge}${tags}
           </div>
+        </div>
+        ${menuBtn}
+      </div>`;
+  }
+
+  private _menu(exp: Expense): string {
+    const c = exp.clasificacion;
+    return `
+      <div class="exp-menu" data-exp-menu>
+        <span class="exp-menu__label">Clasificar como</span>
+        <div class="exp-menu__actions">
+          <button class="exp-menu__btn${c === 'necesidad' ? ' exp-menu__btn--active exp-menu__btn--necesidad' : ''}"
+            data-classify="necesidad" data-exp-id="${exp._id}">Necesidad</button>
+          <button class="exp-menu__btn${c === 'deseo' ? ' exp-menu__btn--active exp-menu__btn--deseo' : ''}"
+            data-classify="deseo" data-exp-id="${exp._id}">Deseo</button>
+          <button class="exp-menu__btn${!c ? ' exp-menu__btn--active' : ''}"
+            data-classify="" data-exp-id="${exp._id}">Sin clasificar</button>
         </div>
       </div>`;
   }


### PR DESCRIPTION
## Resumen

- Botón ⋮ en cada fila de gasto que abre un panel inline con los tres botones de clasificación (Necesidad / Deseo / Sin clasificar), con el estado activo resaltado
- El panel se cierra al pulsar ⋮ de nuevo, seleccionar una opción, o hacer click fuera
- Fix responsive: layout correcto en móvil (≤767 px) y pantallas muy pequeñas (≤480 px) — badges y importes siempre visibles

## Test plan

- [ ] 107 tests pasan (`npm test`)
- [ ] Pulsar ⋮ en un gasto abre el panel de clasificación
- [ ] Seleccionar "Necesidad" / "Deseo" / "Sin clasificar" actualiza el badge en la fila y cierra el panel
- [ ] El estado activo queda resaltado al volver a abrir el menú
- [ ] Click fuera del panel lo cierra sin cambiar la clasificación
- [ ] En móvil (≤480 px) el importe se coloca bajo el concepto sin solapamiento
- [ ] Todos los badges son visibles (se envuelven en líneas adicionales si es necesario)

https://claude.ai/code/session_01VfmarvaWJP8Kv6GqUPkA3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfmarvaWJP8Kv6GqUPkA3g)_