### PR TITLE
Fix donut chart Deseos segment including unclassified expenses

### DIFF
--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -213,8 +213,10 @@ const DashboardModule = (() => {
     // Solo préstamos cuya fechaInicio <= hoy (ya arrancados)
     const _loanIdsIniciados = new Set(loans.filter(l=>(l.fechaInicio||'')<=hoyStr).map(l=>l._id));
     const cuotasMesActual        = evsMesActual.filter(e=>e.sourceType==='loan'&&e.tipo==='gasto'&&_loanIdsIniciados.has(e.sourceId)).reduce((s,e)=>s+Math.abs(e.cuantia),0);
-    const gastosBasicosMesActual = evsMesActual.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const ex=expenses.find(ex=>ex._id===e.sourceId);return ex?.basico;}).reduce((s,e)=>s+Math.abs(e.cuantia),0);
-    const gastosOtrosMesActual   = evsMesActual.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const ex=expenses.find(ex=>ex._id===e.sourceId);return !ex?.basico;}).reduce((s,e)=>s+Math.abs(e.cuantia),0);
+    // clasificacion: 'necesidad'|undefined = necesidad (default); 'deseo' = deseo; null = excluido
+    const _clas = ex => ex?.clasificacion;
+    const gastosBasicosMesActual = evsMesActual.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const c=_clas(expenses.find(ex=>ex._id===e.sourceId));return c!=='deseo'&&c!==null;}).reduce((s,e)=>s+Math.abs(e.cuantia),0);
+    const gastosOtrosMesActual   = evsMesActual.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const c=_clas(expenses.find(ex=>ex._id===e.sourceId));return c==='deseo';}).reduce((s,e)=>s+Math.abs(e.cuantia),0);
     const gastosTosMesActual     = cuotasMesActual + gastosBasicosMesActual + gastosOtrosMesActual;
 
     const dS = new Date(config.dashboardStart+'T00:00:00');
@@ -227,7 +229,8 @@ const DashboardModule = (() => {
     const cuotasMediaMes          = evSinTransf.filter(e=>e.sourceType==='loan'&&e.tipo==='gasto').reduce((s,e)=>s+Math.abs(e.cuantia),0) / numMeses;
     const amortizacionesMediaMes  = evSinTransf.filter(e=>e.sourceType==='loan-amort').reduce((s,e)=>s+Math.abs(e.cuantia),0) / numMeses;
     const gastosMediaMes          = evSinTransf.filter(e=>e.tipo==='gasto'&&e.sourceType!=='loan'&&e.sourceType!=='loan-amort').reduce((s,e)=>s+Math.abs(e.cuantia),0) / numMeses;
-    const gastosBasicosMediaMes = evSinTransf.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const ex=expenses.find(ex=>ex._id===e.sourceId);return ex?.basico;}).reduce((s,e)=>s+Math.abs(e.cuantia),0) / numMeses;
+    const gastosBasicosMediaMes = evSinTransf.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const c=_clas(expenses.find(ex=>ex._id===e.sourceId));return c!=='deseo'&&c!==null;}).reduce((s,e)=>s+Math.abs(e.cuantia),0) / numMeses;
+    const gastosDeseoMediaMes   = evSinTransf.filter(e=>e.tipo==='gasto'&&e.sourceType==='expense').filter(e=>{const c=_clas(expenses.find(ex=>ex._id===e.sourceId));return c==='deseo';}).reduce((s,e)=>s+Math.abs(e.cuantia),0) / numMeses;
 
     // ── Salud financiera — métricas para mes actual y media ──────────────────────
     const _hipotecaIds = new Set(loans.filter(l => (l.tags||[]).includes(config.saludTagHipoteca||'hipoteca')).map(l => l._id));
@@ -236,7 +239,7 @@ const DashboardModule = (() => {
     const cuotasHipotecaMedia = evSinTransf.filter(e=>e.sourceType==='loan'&&e.tipo==='gasto'&&_hipotecaIds.has(e.sourceId)).reduce((s,e)=>s+Math.abs(e.cuantia),0)/numMeses;
 
     const _metSaludMes = { ingresos:ingresosMesActual, cuotas:cuotasMesActual, cuotasHipoteca:cuotasHipotecaMesActual, gastosBasicos:gastosBasicosMesActual, gastosOtros:gastosOtrosMesActual, amortizaciones:amortizacionesMesActual };
-    const _metSaludMedia = { ingresos:ingresosMediaMes, cuotas:cuotasMediaMes, cuotasHipoteca:cuotasHipotecaMedia, gastosBasicos:gastosBasicosMediaMes, gastosOtros:gastosMediaMes-gastosBasicosMediaMes, amortizaciones:amortizacionesMediaMes };
+    const _metSaludMedia = { ingresos:ingresosMediaMes, cuotas:cuotasMediaMes, cuotasHipoteca:cuotasHipotecaMedia, gastosBasicos:gastosBasicosMediaMes, gastosOtros:gastosDeseoMediaMes, amortizaciones:amortizacionesMediaMes };
     const saludMes   = FinanceMath.calcSaludFinanciera(_metSaludMes, config);
     const saludMedia = FinanceMath.calcSaludFinanciera(_metSaludMedia, config);
 
@@ -670,11 +673,11 @@ const DashboardModule = (() => {
         <div class="card">
           <div class="card-title mb-8">Distribución media mensual (periodo)</div>
           ${(()=>{
-            const otrosGastosMed = Math.max(0, gastosMediaMes - gastosBasicosMediaMes - totalTagPromoMediaMes);
-            const ahorroMed      = Math.max(0, ingresosMediaMes - cuotasMediaMes - gastosMediaMes - amortizacionesMediaMes);
-            const totalRef       = ingresosMediaMes > 0 ? ingresosMediaMes : (cuotasMediaMes + gastosMediaMes + amortizacionesMediaMes + 0.01);
+            const deseosMed      = Math.max(0, gastosDeseoMediaMes - totalTagPromoMediaMes);
+            const ahorroMed      = Math.max(0, ingresosMediaMes - cuotasMediaMes - gastosBasicosMediaMes - gastosDeseoMediaMes - amortizacionesMediaMes);
+            const totalRef       = ingresosMediaMes > 0 ? ingresosMediaMes : (cuotasMediaMes + gastosBasicosMediaMes + gastosDeseoMediaMes + amortizacionesMediaMes + 0.01);
             const pctBasicos = (gastosBasicosMediaMes / totalRef * 100).toFixed(1);
-            const pctOtros   = (otrosGastosMed / totalRef * 100).toFixed(1);
+            const pctOtros   = (deseosMed / totalRef * 100).toFixed(1);
             const pctDeuda   = (cuotasMediaMes / totalRef * 100).toFixed(1);
             const pctAmort   = (amortizacionesMediaMes / totalRef * 100).toFixed(1);
             const pctAhorro  = (ahorroMed / totalRef * 100).toFixed(1);
@@ -688,13 +691,13 @@ const DashboardModule = (() => {
             <div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap">
               <div style="position:relative;width:140px;height:140px;flex-shrink:0"><canvas id="chart-expense-donut"></canvas></div>
               <div style="flex:1;min-width:130px;display:flex;flex-direction:column;gap:7px">
-                ${legendRow('#4d9fff','Básicos',gastosBasicosMediaMes,pctBasicos)}
+                ${legendRow('#4d9fff','Necesidades',gastosBasicosMediaMes,pctBasicos)}
                 ${tagCategorias.map((t,i)=>{
                   const v=_tagPromoMediaMes[t]||0; if(v<0.01)return '';
                   const c=_TAG_PROMO_PALETTE[i%_TAG_PROMO_PALETTE.length];
                   return legendRow(c,t,v,(v/totalRef*100).toFixed(1));
                 }).join('')}
-                ${legendRow('#ff4d6d','Otros gastos',otrosGastosMed,pctOtros)}
+                ${deseosMed > 0.01 ? legendRow('#ffd166','Deseos',deseosMed,pctOtros) : ''}
                 ${legendRow('#a855f7','Deuda',cuotasMediaMes,pctDeuda)}
                 ${amortizacionesMediaMes > 0.01 ? legendRow('#fb923c','Amortizaciones',amortizacionesMediaMes,pctAmort) : ''}
                 <div style="display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:12px;border-top:1px solid var(--border);padding-top:6px">
@@ -1527,9 +1530,9 @@ const DashboardModule = (() => {
       .map((t, i) => ({ label: t, value: tagPromoMediaMes[t] || 0, color: _TAG_PROMO_PALETTE[i % _TAG_PROMO_PALETTE.length] }))
       .filter(s => s.value > 0.01);
     const segments = [
-      { label:'Básicos',         value: gastosBasicosMediaMes, color:'#4d9fff' },
+      { label:'Necesidades',     value: gastosBasicosMediaMes, color:'#4d9fff' },
       ...promoSegments,
-      { label:'Otros gastos',    value: otrosGastos,           color:'#ff4d6d' },
+      { label:'Deseos',          value: otrosGastos,           color:'#ffd166' },
       { label:'Deuda',           value: cuotasMediaMes,        color:'#a855f7' },
       { label:'Amortizaciones',  value: amortizacionesMediaMes,color:'#fb923c' },
       { label:'Ahorro est.',     value: ahorro,                color:'#00e5a0' },

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -968,7 +968,7 @@ const DashboardModule = (() => {
 
     // Pass computed metrics to chart functions
     const _metricasGraficos = { loans, expenses, config, numMeses, extracto, tagCategorias };
-    const _donutMetrics = { gastosBasicosMediaMes, gastosMediaMes, cuotasMediaMes, ingresosMediaMes, amortizacionesMediaMes, tagPromoMediaMes: _tagPromoMediaMes };
+    const _donutMetrics = { gastosBasicosMediaMes, gastosDeseoMediaMes, gastosMediaMes, cuotasMediaMes, ingresosMediaMes, amortizacionesMediaMes, tagPromoMediaMes: _tagPromoMediaMes };
     // Breakdown "otros gastos" por tag (media mensual del periodo), excluding promoted tags
     const _otrosTagMap = {};
     evSinTransf.filter(e => e.tipo === 'gasto' && e.sourceType === 'expense').forEach(e => {
@@ -1520,12 +1520,12 @@ const DashboardModule = (() => {
     });
   }
 
-  function renderChartExpenseDonut({ gastosBasicosMediaMes, gastosMediaMes, cuotasMediaMes, ingresosMediaMes, amortizacionesMediaMes=0, tagPromoMediaMes={} }) {
+  function renderChartExpenseDonut({ gastosBasicosMediaMes, gastosDeseoMediaMes=0, gastosMediaMes, cuotasMediaMes, ingresosMediaMes, amortizacionesMediaMes=0, tagPromoMediaMes={} }) {
     const ctx = document.getElementById('chart-expense-donut'); if (!ctx) return;
     const tagCategorias = State.get('config').tagCategorias || [];
     const totalTagPromo = tagCategorias.reduce((s, t) => s + (tagPromoMediaMes[t] || 0), 0);
-    const otrosGastos = Math.max(0, gastosMediaMes - gastosBasicosMediaMes - totalTagPromo);
-    const ahorro      = Math.max(0, ingresosMediaMes - cuotasMediaMes - gastosMediaMes - amortizacionesMediaMes);
+    const otrosGastos = Math.max(0, gastosDeseoMediaMes - totalTagPromo);
+    const ahorro      = Math.max(0, ingresosMediaMes - cuotasMediaMes - gastosBasicosMediaMes - gastosDeseoMediaMes - amortizacionesMediaMes);
     const promoSegments = tagCategorias
       .map((t, i) => ({ label: t, value: tagPromoMediaMes[t] || 0, color: _TAG_PROMO_PALETTE[i % _TAG_PROMO_PALETTE.length] }))
       .filter(s => s.value > 0.01);

--- a/expenses/expenses.js
+++ b/expenses/expenses.js
@@ -132,6 +132,8 @@ const ExpensesModule = (() => {
       <div class="text-sm exp-col-hide">${cuentaLabel}</div>
       <div class="flex gap-8 items-center exp-col-hide">
         <label class="toggle"><input type="checkbox" data-tog-exp="${exp._id}" ${exp.activo?'checked':''}/><span class="toggle-slider"></span></label>
+        ${exp.tipo==='gasto'&&exp.clasificacion==='deseo'?'<span class="badge" style="background:rgba(255,209,102,0.15);color:#ffd166" title="Gasto clasificado como deseo">deseo</span>':''}
+        ${exp.tipo==='gasto'&&exp.clasificacion===null?'<span class="badge badge-inactive" title="Excluido del análisis de distribución">sin clasificar</span>':''}
         ${exp.basico?'<span class="badge badge-orange" title="Gasto básico">⚑ básico</span>':''}
         ${expirado?'<span class="badge badge-inactive">Exp.</span>':''}
       </div>
@@ -178,6 +180,9 @@ const ExpensesModule = (() => {
           <div class="mt-8">${UI.input('ef-fecha-fin','Fecha fin (opcional)','date',exp?.fechaFin||'')}</div>
           <div class="mt-8">${UI.diaPagoWidget('exp', exp?.diaPago||'')}</div>
           <div id="ef-basico-wrap" style="${isTransfer?'display:none':''}">
+            <div class="mt-8" id="ef-clasificacion-wrap" style="${exp?.tipo==='ingreso'?'display:none':''}">
+              ${UI.select('ef-clasificacion','Clasificación del gasto',[['necesidad','Necesidad'],['deseo','Deseo'],['','Sin clasificar (excluido del análisis)']],exp?.clasificacion??'necesidad')}
+            </div>
             <div class="form-group mt-8"><label class="form-label">Etiquetas (separadas por coma)</label><input class="form-input" type="text" id="ef-tags" value="${(exp?.tags||[]).join(', ')}" placeholder="alquiler, vivienda"/></div>
             <div class="form-row mt-8">
               <label class="form-label">Gasto básico</label>
@@ -215,6 +220,8 @@ const ExpensesModule = (() => {
         document.getElementById('ef-varianza-wrap').style.display  = t==='transferencia' ? 'none' : '';
         const irpfWrap = document.getElementById('ef-irpf-wrap');
         if(irpfWrap) irpfWrap.style.display = t==='ingreso' ? '' : 'none';
+        const clasificWrap = document.getElementById('ef-clasificacion-wrap');
+        if(clasificWrap) clasificWrap.style.display = t==='gasto' ? '' : 'none';
       };
     }, 50);
   }
@@ -244,6 +251,7 @@ const ExpensesModule = (() => {
       varianza:      isTransfer ? 0 : (parseFloat(document.getElementById('ef-varianza')?.value)||0),
       inflacion:     isTransfer ? 0 : (parseFloat(document.getElementById('ef-inflacion')?.value)||0),
       sujetoIRPF:    !isTransfer && (document.getElementById('ef-sujetoIRPF')?.checked||false),
+      clasificacion: tipo==='gasto' ? (document.getElementById('ef-clasificacion')?.value||null) : undefined,
       tags:          isTransfer ? ['transferencia'] : (document.getElementById('ef-tags')?.value||'').split(',').map(t=>t.trim()).filter(Boolean),
       escenarioIds:  EscenariosModule.readCheckedEscenarios(),
     };


### PR DESCRIPTION
## Summary

- The Chart.js donut "Deseos" segment was using `gastosMediaMes - gastosBasicosMediaMes` which included *sin-clasificar* expenses, making the yellow slice appear ~30% while the legend correctly showed 8.2%
- Fixed by passing `gastosDeseoMediaMes` through `_donutMetrics` to `renderChartExpenseDonut` and using it directly for the Deseos segment
- Ahorro calculation in the chart also corrected to exclude unclassified expenses (matching the legend logic)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfmarvaWJP8Kv6GqUPkA3g)_